### PR TITLE
Optimize CUDA analysis pipeline and automatic workflow

### DIFF
--- a/docs/adr/0004-bounded-cuda-analysis-pipeline.md
+++ b/docs/adr/0004-bounded-cuda-analysis-pipeline.md
@@ -1,0 +1,71 @@
+# ADR 0004: Bounded CUDA analysis pipeline
+
+## Status
+
+Accepted
+
+## Context
+
+TrackNet analysis previously decoded and assembled one Batch, synchronously
+copied it to CUDA, ran the model, copied the result back, and completed all CPU
+postprocessing before decoding the next Batch. At production `batch=4`,
+`seq_len=8`, `bg_mode=concat`, and `280x160`, one input Batch is about 18.5 MiB.
+Per-sequence `concatenate` calls and a per-Batch `stack` also copied that data
+more than once.
+
+Running several model forwards concurrently would increase device-memory
+pressure and can change scheduling without removing the CPU preparation
+bottleneck. Unbounded prefetch would make memory usage depend on video length
+and would complicate cancellation.
+
+## Decision
+
+CUDA analysis uses one bounded, ordered pipeline:
+
+```text
+CPU Producer -> Ready Queue (2) -> one GPU Consumer
+             -> Result Queue (2) -> CPU Postprocessor
+```
+
+Three reusable Buffer Slots move through:
+
+```text
+FREE -> FILLING -> READY -> GPU_RUNNING
+     -> RESULT_READY -> POSTPROCESSING -> FREE
+```
+
+The Producer decodes, crops, resizes, and writes directly into a Slot's final
+Batch allocation. The GPU Consumer is the coordinating thread and enqueues only
+one TrackNet forward at a time. The Postprocessor consumes Batch ordinals in
+FIFO order and is the only owner of trajectory history and progress updates.
+Queue operations use bounded waits and a shared stop event; the first error is
+preserved and both worker threads are joined before return or rethrow.
+
+CUDA Slots normally use persistent pinned input and output tensors. The
+Producer writes through the pinned input tensor's NumPy view. A dedicated H2D
+stream, one compute stream, two reusable device-input buffers, and per-Slot
+CUDA Events enforce buffer ownership and permit H2D for the next Batch to
+overlap the current forward. The Postprocessor synchronizes only the Event for
+the Slot it is about to read. Pinned allocation failure before decoding starts
+falls back to the same bounded pipeline with pageable memory and synchronous
+transfers.
+
+CPU analysis reuses direct Batch filling but remains serial. The implementation
+uses only Python `threading`, `queue.Queue`, and PyTorch CUDA primitives; it
+adds no Windows API, process, shared-memory, or external dependency.
+
+## Consequences
+
+- Batch order, model inputs, trajectory history, progress meaning, public
+  Worker JSONL, and Electron IPC remain unchanged.
+- Queue capacity and three Slot objects put a fixed upper bound on prefetched
+  Host memory.
+- A single model and compute stream avoid concurrent-forward VRAM spikes.
+- Cancellation and errors cannot rely on blocking queue operations; every
+  stage must observe the shared stop event and all threads must be joined.
+- The pinned/Event layer is more complex and its isolated speed benefit was not
+  demonstrated by the single formal run. It remains useful for explicit
+  ownership and asynchronous transfer, while the performance report labels the
+  measured change as uncertain.
+- Windows 10 22H2 x64 and Windows 11 x64 Client keep the existing support
+  boundary. This decision does not constitute Windows 10 hardware validation.

--- a/docs/performance/tracknet-cuda-pipeline-2026-07-27.md
+++ b/docs/performance/tracknet-cuda-pipeline-2026-07-27.md
@@ -1,0 +1,107 @@
+# TrackNet CUDA pipeline performance report — 2026-07-27
+
+## Result
+
+The final Predictor completed in **78.931 s**, versus **125.922 s** for the
+untouched baseline: **46.992 s shorter (37.32%)**. This exceeds the 10%
+acceptance threshold.
+
+The Pinned Buffer / asynchronous transfer step alone measured 1.43% slower
+than the synchronous bounded pipeline. Because the plan treats changes below
+5% as measurement uncertainty, that step has **no demonstrated performance
+benefit** in this single-run experiment.
+
+## Fixed inputs
+
+- Baseline Git branch / HEAD: `fix/cudatest` /
+  `46f14ff1085603f2367af0d61824bd754362d2a8`
+- Video: Istanbul 2026 final, 101,153,938 bytes
+- Video SHA-256:
+  `9bf7676b1a3a400d3318f26393f263b73fe2c834692d35ac66f4fa33c42083ed`
+- Calibration SHA-256:
+  `8068c2542b23fd4c3b9bae839fd63bc8424ab131f0fb68edf24023a17dd1379f`
+- Model SHA-256:
+  `ffb5469161c4bd39a5a7e745c3d13f076b2c5e575f33279ea62f1e5803245a52`
+- Device / Batch / sequence / background: CUDA / 4 / 8 / `concat`
+- Analysis ROI: `(487, 238)–(1307, 707)`, source size `1920x1080`
+- Model input: `280x160`, FP32
+
+The source-video hash was identical before and after every formal run.
+
+## Environment
+
+- Windows 11 build 26100, x64
+- NVIDIA GeForce RTX 4060 Laptop GPU, 8,188 MiB
+- NVIDIA driver 566.36
+- Python 3.12.13
+- PyTorch 2.12.1+cu126 / CUDA runtime 12.6
+- OpenCV 4.13.0 / NumPy 2.5.1
+
+## Formal single-run checkpoints
+
+| Checkpoint | Predictor | Forward | FPS | vs previous | vs baseline |
+|---|---:|---:|---:|---:|---:|
+| Untouched baseline | 125.922 s | 30.830 s | 159.87 | — | — |
+| Preallocated assembly | 96.949 s | 22.347 s | 207.65 | 28.974 s / 23.01% faster | 23.01% faster |
+| Bounded pipeline | 77.820 s | 25.584 s | 258.69 | 19.129 s / 19.73% faster | 38.20% faster |
+| Pinned + async + Events | 78.931 s | 25.267 s | 255.05 | 1.111 s / 1.43% slower | 37.32% faster |
+
+The changed forward timings are not attributed to input allocation: model
+math did not change, and GPU warm-up and system state were not independently
+controlled. `predictor_seconds` is the acceptance metric.
+
+## Output equivalence
+
+A separate end-to-end equivalence run loaded the untouched Predictor directly
+from baseline Git HEAD and compared it with the final implementation:
+
+- Frames: 20,131 in both runs
+- Visible frames: 5,135 in both runs
+- Normalized full trajectory SHA-256, including
+  `frame/time/visibility/x/y/source/confidence/time_source`:
+  `2e70199cd0e8128f466f327f566a28d8a01ebd900a8490a854da4e65502edf59`
+- Maximum absolute confidence difference: `0`
+- Bounce frames: identical, 165
+- Rally summaries: identical, 41
+- Source video hash before/after: identical
+
+Raw checkpoint and equivalence JSON files remain in the ignored local
+`.baseline/analysis-pipeline/20260727-cuda-pipeline/` directory.
+
+## Interpretation and limits
+
+Each formal checkpoint is one complete run on one laptop, so the measurements
+do not provide confidence intervals. Differences below 5% are deliberately
+reported as uncertain. The final 37.32% cumulative reduction is well above the
+10% threshold, but repeated runs would be required to estimate a stable mean.
+
+The implementation changes allocation and scheduling only. It does not change
+the model, checkpoint, ROI, thresholds, Batch size, bounce/rally rules, Worker
+protocol, Electron IPC, or UI.
+
+Windows 11 has live execution evidence in this run. Windows 10 22H2 x64 receives
+only static compatibility evidence: no new Windows API or build gate, no new
+DLL/runtime dependency, no `multiprocessing` or shared memory, and unchanged
+Python/PyTorch/OpenCV packaging. This report does not claim Windows 10 hardware
+validation.
+
+## Final validation
+
+- Worker Python: 44 passed.
+- TypeScript typecheck: passed.
+- Vitest: 25 files / 78 tests passed; 3 files / 8 tests retained their existing
+  conditional skips.
+- CPU smoke: existing `2.12.1+cpu` managed runtime, 301-frame Istanbul clip,
+  `280x160`, batch 4, serial Predictor; 9.047 s and 33.27 FPS.
+- Model asset validation and local Windows x64 Electron Forge package: passed.
+- Source, staged, and packaged Predictor SHA-256:
+  `5f711f4a936839cf71b4e4545d29a307b00ef2ee81e14029c2dd780beff0b21f`.
+- Real Electron CUDA E2E with explicit `1-193.mp4`, CUDA runtime, model, and
+  FFmpeg: passed in 52.5 s. It completed analysis, persisted History, played
+  the third-rally preview, exported one rally, and loaded the final video.
+- The E2E's former fixed expectation of 47 rallies was checked against the
+  untouched `46f14ff` Predictor and found stale: the baseline produces 41
+  rallies with the same Calibration, including rally 3 at 32.032–38.204 s.
+  Only the test expectation was updated.
+- Windows diagnostic: Windows 11 24H2 build 26100, Client, x64, 100% DPI,
+  compatibility status `supported`. No installer or signing smoke was run.

--- a/scripts/benchmark-analysis-pipeline.py
+++ b/scripts/benchmark-analysis-pipeline.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import platform
+import subprocess
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+WORKER_ROOT = PROJECT_ROOT / "worker"
+if str(WORKER_ROOT) not in sys.path:
+    sys.path.insert(0, str(WORKER_ROOT))
+
+from ttcut_worker.bounce import detect_bounce_frames  # noqa: E402
+from ttcut_worker.calibration import TableCalibration  # noqa: E402
+from ttcut_worker.model import load_tracknet  # noqa: E402
+from ttcut_worker.rallies import group_rallies  # noqa: E402
+from ttcut_worker.roi import build_analysis_roi  # noqa: E402
+
+DEFAULT_VIDEO = Path(
+    r"D:\DOCUMENTS\TrackNetV3_TableTennis\testvideoes"
+    r"\Maharu Yoshimura vs Andrej Gacina - MS Final - WTT Feeder Istanbul 2026.mp4"
+)
+DEFAULT_CALIBRATION = Path(
+    r"D:\DOCUMENTS\table_analyze\outputs\istanbul_2026_calibration"
+    r"\Maharu Yoshimura vs Andrej Gacina - MS Final - WTT Feeder Istanbul 2026_calibration.json"
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_calibration(path: Path) -> TableCalibration:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if "video_info" in payload:
+        width = int(payload["video_info"]["width"])
+        height = int(payload["video_info"]["height"])
+        points = payload.get("planar_homography", {}).get("image_points")
+        if points is None:
+            points = payload["calibration"]["points"]
+    else:
+        calibration = payload["calibration"]
+        width = int(calibration["video_width"])
+        height = int(calibration["video_height"])
+        values = calibration["points"]
+        points = [
+            values["top_left"],
+            values["top_right"],
+            values["bottom_right"],
+            values["bottom_left"],
+        ]
+    return TableCalibration.from_points(width, height, points)
+
+
+def predictor_class(source_ref: str | None):
+    if source_ref is None:
+        from ttcut_worker.predictor import TrackNetPredictor
+
+        return TrackNetPredictor
+    result = subprocess.run(
+        [
+            "git",
+            "show",
+            f"{source_ref}:worker/ttcut_worker/predictor.py",
+        ],
+        cwd=PROJECT_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_loader(
+        "ttcut_worker._benchmark_predictor",
+        loader=None,
+    )
+    if spec is None:
+        raise RuntimeError("Unable to create the benchmark Predictor module.")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    exec(compile(result.stdout, "<benchmark-predictor>", "exec"), module.__dict__)
+    return module.TrackNetPredictor
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run one reproducible TrackNetPredictor analysis checkpoint.",
+    )
+    parser.add_argument("--video", type=Path, default=DEFAULT_VIDEO)
+    parser.add_argument("--calibration", type=Path, default=DEFAULT_CALIBRATION)
+    parser.add_argument(
+        "--weights",
+        type=Path,
+        default=PROJECT_ROOT / "resources" / "models" / "analyze.pt",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--device", choices=("cuda", "cpu"), default="cuda")
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--model-size", default="280x160")
+    parser.add_argument(
+        "--predictor-source-ref",
+        help="Load predictor.py from this Git ref for equivalence checks.",
+    )
+    args = parser.parse_args()
+    model_size = None
+    if args.model_size.lower() != "auto":
+        width, height = (
+            int(value) for value in args.model_size.lower().split("x", 1)
+        )
+        model_size = (width, height)
+    calibration = read_calibration(args.calibration)
+    roi = build_analysis_roi(calibration)
+    source_before = sha256(args.video)
+    model_hash = sha256(args.weights)
+
+    import cv2
+    import numpy as np
+    import torch
+
+    load_started = time.perf_counter()
+    loaded = load_tracknet(args.weights, args.device)
+    model_load_seconds = time.perf_counter() - load_started
+    Predictor = predictor_class(args.predictor_source_ref)
+    last_progress = [-1]
+
+    def progress(current: int, total: int) -> None:
+        if current == total or current - last_progress[0] >= 1024:
+            print(f"predictor: {current}/{total}", flush=True)
+            last_progress[0] = current
+
+    points, info, stats = Predictor(loaded, batch_size=args.batch_size).predict(
+        args.video,
+        progress_callback=progress,
+        analysis_roi=roi,
+        model_size=model_size,
+    )
+    point_rows = [asdict(point) for point in points]
+    canonical = json.dumps(
+        point_rows,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    bounces = detect_bounce_frames(points, calibration)
+    rallies = group_rallies(bounces, points)
+    payload = {
+        "environment": {
+            "windows": platform.platform(),
+            "python": platform.python_version(),
+            "pytorch": torch.__version__,
+            "cuda_runtime": torch.version.cuda,
+            "gpu": torch.cuda.get_device_name(0) if args.device == "cuda" else None,
+            "opencv": cv2.__version__,
+            "numpy": np.__version__,
+        },
+        "inputs": {
+            "video": str(args.video.resolve()),
+            "video_sha256_before": source_before,
+            "video_sha256_after": sha256(args.video),
+            "weights": str(args.weights.resolve()),
+            "weights_sha256": model_hash,
+            "calibration": str(args.calibration.resolve()),
+            "batch_size": args.batch_size,
+            "sequence_length": loaded.seq_len,
+            "background_mode": loaded.bg_mode,
+            "analysis_roi": asdict(roi),
+            "model_size": list(model_size) if model_size else "auto",
+            "predictor_source_ref": args.predictor_source_ref,
+        },
+        "timing": {
+            "model_load_seconds": model_load_seconds,
+            **asdict(stats),
+        },
+        "output": {
+            "frames": info.decoded_frame_count,
+            "visible_frames": sum(point.visibility for point in points),
+            "trajectory_sha256": hashlib.sha256(canonical).hexdigest(),
+            "confidences": [point.confidence for point in points],
+            "bounce_frames": bounces,
+            "rallies": [asdict(rally) for rally in rallies],
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(payload["timing"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/domain/analysis-progress.ts
+++ b/src/domain/analysis-progress.ts
@@ -6,13 +6,13 @@ const MANUAL_ANALYSIS_RANGES: Record<string, readonly [number, number]> = {
 };
 
 const AUTOMATIC_ANALYSIS_RANGES: Record<string, readonly [number, number]> = {
-  probe: [0, 3],
-  table_sampling: [3, 18],
-  table_model: [18, 25],
-  table_inference: [25, 32],
-  load_model: [32, 40],
-  analysis: [40, 96],
-  postprocess: [96, 100],
+  probe: [0, 0],
+  table_sampling: [0, 2],
+  table_model: [2, 3],
+  table_inference: [3, 5],
+  load_model: [5, 5],
+  analysis: [5, 100],
+  postprocess: [100, 100],
 };
 
 export function overallAnalysisProgress(

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -348,6 +348,11 @@ export function App() {
 
   useEffect(() => { settingsRef.current = settings; }, [settings]);
   useEffect(() => {
+    if (!toast) return;
+    const timeout = window.setTimeout(() => setToast(null), 3_000);
+    return () => window.clearTimeout(timeout);
+  }, [toast]);
+  useEffect(() => {
     if (updateState.status !== 'downloaded' || promptedUpdateVersion.current === updateState.version) return;
     promptedUpdateVersion.current = updateState.version;
     if (window.confirm(`TTcut ${updateState.version ?? ''} 已下载完成。立即重启安装？\n选择“取消”可稍后重启。`)) {
@@ -378,7 +383,6 @@ export function App() {
       await acceptVideo(selected[0] ?? null);
       return;
     }
-    if (!window.confirm('测试内容，确认以继续')) return;
     multiActiveRef.current = true;
     setMultiVideos(selected);
     setView('multi');

--- a/tests/analysis-progress.test.ts
+++ b/tests/analysis-progress.test.ts
@@ -2,9 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { overallAnalysisProgress } from '../src/domain/analysis-progress';
 
 describe('analysis progress mapping', () => {
-  it('maps TrackNet analysis stages to the full progress range', () => {
+  it('keeps the manual TrackNet analysis mapping unchanged', () => {
     expect(overallAnalysisProgress('load_model', 100)).toBe(10);
     expect(overallAnalysisProgress('analysis', 50)).toBe(53);
     expect(overallAnalysisProgress('postprocess', 100)).toBe(100);
+  });
+
+  it('reserves 5% for automatic calibration and 95% for analysis', () => {
+    expect(overallAnalysisProgress('table_sampling', 50, 'automatic')).toBe(1);
+    expect(overallAnalysisProgress('table_model', 100, 'automatic')).toBe(3);
+    expect(overallAnalysisProgress('table_inference', 100, 'automatic')).toBe(5);
+    expect(overallAnalysisProgress('load_model', 100, 'automatic')).toBe(5);
+    expect(overallAnalysisProgress('analysis', 50, 'automatic')).toBe(52.5);
+    expect(overallAnalysisProgress('postprocess', 100, 'automatic')).toBe(100);
   });
 });

--- a/tests/app-workflow.test.tsx
+++ b/tests/app-workflow.test.tsx
@@ -1,0 +1,145 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { App } from '../src/renderer/App';
+import type { AppEvent, BootstrapData, SelectedVideo, TTcutApi } from '../src/shared/api';
+import type { VideoMetadata } from '../src/shared/contracts';
+
+const bootstrap: BootstrapData = {
+  version: '1.1.0-beta',
+  settings: {
+    language: 'zh-CN',
+    calibration_method: 'automatic',
+    export_strategy: 'compatible',
+    pre_roll_seconds: 2.5,
+    post_roll_seconds: 2,
+  },
+  components: {
+    analysis: {
+      available: true,
+      version: 'Python 3.12.13',
+      path: 'C:\\runtime\\python.exe',
+      acceleration: 'cuda',
+      detail: null,
+    },
+    media: {
+      available: true,
+      version: 'ffmpeg 8.1',
+      path: 'C:\\ffmpeg\\ffmpeg.exe',
+      active_encoder: 'libopenh264',
+      x264_available: false,
+      detail: null,
+    },
+  },
+  componentSetup: {
+    analysis_offer: null,
+    media_offer: null,
+    x264_manual_offer: {
+      id: 'media-x264',
+      version: 'N-125716-g1b1f602699',
+      filename: 'ffmpeg-x264.zip',
+      download_size_bytes: 1,
+      license_url: 'https://example.com/license',
+    },
+  },
+  platformCompatibility: {
+    status: 'supported',
+    reason: 'supported',
+    platform: 'win32',
+    architecture: 'x64',
+    build_number: 26100,
+    installation_type: 'Client',
+  },
+  logsPath: 'C:\\logs',
+};
+
+function metadata(path: string): VideoMetadata {
+  return {
+    path,
+    duration_seconds: 10,
+    width: 1280,
+    height: 720,
+    fps: 30,
+    variable_frame_rate: false,
+    video_codec: 'h264',
+    audio_codec: 'aac',
+    container: 'mp4',
+  };
+}
+
+describe('App workflow notices and multi-task entry', () => {
+  let taskListener: ((event: AppEvent) => void) | null;
+  let selectVideos: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    taskListener = null;
+    selectVideos = vi.fn().mockResolvedValue([]);
+    const api = {
+      bootstrap: vi.fn().mockResolvedValue(bootstrap),
+      onTaskEvent: vi.fn((listener: (event: AppEvent) => void) => {
+        taskListener = listener;
+        return () => { taskListener = null; };
+      }),
+      onCloseRequested: vi.fn(() => () => undefined),
+      onUpdateState: vi.fn(() => () => undefined),
+      getUpdateState: vi.fn().mockResolvedValue({
+        status: 'idle',
+        version: null,
+        message: null,
+      }),
+      selectVideos,
+      probeVideo: vi.fn((path: string) => Promise.resolve(metadata(path))),
+    } as unknown as TTcutApi;
+    Object.defineProperty(window, 'ttcut', { configurable: true, value: api });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('hides the automatic calibration failure notice after three seconds', async () => {
+    render(<App />);
+    await screen.findByRole('heading', { name: '选择比赛视频' });
+    vi.useFakeTimers();
+
+    act(() => taskListener?.({
+      type: 'error',
+      taskId: 'analysis-task',
+      code: 'AUTO_CALIBRATION_FAILED',
+      message: 'AUTO_CALIBRATION_FAILED',
+    }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('自动标定不可靠，请改用手动标定。');
+    act(() => vi.advanceTimersByTime(2_999));
+    expect(screen.getByRole('status')).toBeVisible();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('opens multi-task clipping directly without the test confirmation', async () => {
+    const videos: SelectedVideo[] = [
+      {
+        path: 'C:\\video\\first.mp4',
+        name: 'first.mp4',
+        size: 100,
+        mediaUrl: 'ttcut-media://first',
+      },
+      {
+        path: 'C:\\video\\second.mp4',
+        name: 'second.mp4',
+        size: 200,
+        mediaUrl: 'ttcut-media://second',
+      },
+    ];
+    selectVideos.mockResolvedValue(videos);
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    render(<App />);
+    await screen.findByRole('heading', { name: '选择比赛视频' });
+
+    fireEvent.click(screen.getByRole('button', { name: /选择 MP4 视频/ }));
+
+    await screen.findByRole('heading', { name: '多任务剪辑' });
+    await waitFor(() => expect(screen.getByText('first.mp4')).toBeVisible());
+    expect(confirm).not.toHaveBeenCalled();
+  });
+});

--- a/tests/e2e/real-workflow.spec.ts
+++ b/tests/e2e/real-workflow.spec.ts
@@ -278,12 +278,12 @@ test('real CUDA analysis, single-rally export, and final preview', async ({}, te
     await page.getByRole('button', { name: '开始分析' }).click();
 
     await expect(page.getByRole('heading', { name: '选择剪辑模式' })).toBeVisible({ timeout: 7 * 60 * 1_000 });
-    await expect(page.getByText('已识别 47 个有效回合', { exact: true })).toBeVisible();
+    await expect(page.getByText('已识别 41 个有效回合', { exact: true })).toBeVisible();
     await page.screenshot({ path: path.join(screenshotDir, '02-real-analysis.png'), fullPage: true });
 
     await page.getByRole('button', { name: '历史剪辑' }).click();
     await expect(page.getByText(path.basename(fixtureVideo), { exact: true })).toBeVisible();
-    await expect(page.getByText('47 个回合', { exact: true })).toBeVisible();
+    await expect(page.getByText('41 个回合', { exact: true })).toBeVisible();
     const historyCover = page.locator('.history-cover img');
     await expect(historyCover).toBeVisible();
     await expect.poll(() => historyCover.evaluate((element: HTMLImageElement) => ({ complete: element.complete, width: element.naturalWidth }))).toMatchObject({ complete: true, width: 640 });
@@ -294,19 +294,19 @@ test('real CUDA analysis, single-rally export, and final preview', async ({}, te
     expect(durationBox!.x + durationBox!.width).toBeLessThanOrEqual(deleteBox!.x - 4);
     await page.locator('.history-open').click();
     await expect(page.getByRole('heading', { name: '选择剪辑模式' })).toBeVisible();
-    await expect(page.getByText('已识别 47 个有效回合', { exact: true })).toBeVisible();
+    await expect(page.getByText('已识别 41 个有效回合', { exact: true })).toBeVisible();
 
     await page.getByRole('button', { name: /自定义/ }).click();
     await expect(page.getByRole('button', { name: '开始剪辑' })).toBeDisabled();
     await page.locator('tbody input[type="checkbox"]').first().check();
     const thirdRallyRow = page.locator('tbody tr').nth(2);
-    await expect(thirdRallyRow).toContainText('00:00:32.065');
-    await expect(thirdRallyRow).toContainText('00:00:37.937');
+    await expect(thirdRallyRow).toContainText('00:00:32.032');
+    await expect(thirdRallyRow).toContainText('00:00:38.204');
     await thirdRallyRow.getByRole('button', { name: '预览' }).click();
     const rallyPreview = page.getByRole('dialog', { name: '回合预览' });
     await expect(rallyPreview).toBeVisible();
     await expect(rallyPreview).toContainText('第 3 回合');
-    await expect(rallyPreview).toContainText('00:00:31.065 – 00:00:38.937');
+    await expect(rallyPreview).toContainText('00:00:31.032 – 00:00:39.204');
     const rallyPreviewState = await rallyPreview.locator('video').evaluate(async (element: HTMLVideoElement) => {
       if (element.readyState < 1) {
         await new Promise<void>((resolve, reject) => {
@@ -329,8 +329,8 @@ test('real CUDA analysis, single-rally export, and final preview', async ({}, te
     });
     expect(rallyPreviewState.controls).toBe(true);
     expect(rallyPreviewState.readyState).toBeGreaterThanOrEqual(1);
-    expect(rallyPreviewState.startTime).toBeGreaterThanOrEqual(31.015);
-    expect(rallyPreviewState.startTime).toBeLessThanOrEqual(31.115);
+    expect(rallyPreviewState.startTime).toBeGreaterThanOrEqual(30.982);
+    expect(rallyPreviewState.startTime).toBeLessThanOrEqual(31.082);
     expect(rallyPreviewState.currentTime).toBeGreaterThan(rallyPreviewState.startTime);
     await rallyPreview.getByRole('button', { name: '关闭预览' }).click();
     await expect(rallyPreview).toBeHidden();

--- a/tests/e2e/real-workflow.spec.ts
+++ b/tests/e2e/real-workflow.spec.ts
@@ -262,7 +262,9 @@ test('real CUDA analysis, single-rally export, and final preview', async ({}, te
 
     const calibrationVideo = page.locator('.video-surface video');
     await expect(calibrationVideo).toBeVisible({ timeout: 90_000 });
-    await expect(page.getByText('自动标定不可靠，请改用手动标定。', { exact: true })).toBeVisible();
+    const automaticCalibrationNotice = page.getByText('自动标定不可靠，请改用手动标定。', { exact: true });
+    await expect(automaticCalibrationNotice).toBeVisible();
+    await expect(automaticCalibrationNotice).toBeHidden({ timeout: 4_000 });
     await calibrationVideo.evaluate(async (element: HTMLVideoElement) => {
       if (element.readyState >= 1) return;
       await new Promise<void>((resolve, reject) => {
@@ -408,6 +410,7 @@ test('automatic calibration completes serial multi-task analysis and records zer
   let page: Page | null = null;
   const nativeStderr: string[] = [];
   const rendererErrors: string[] = [];
+  const dialogs: string[] = [];
   try {
     const port = await freePort();
     electronProcess = spawn(electronPath, [
@@ -445,7 +448,10 @@ test('automatic calibration completes serial multi-task analysis and records zer
     page.on('console', (message) => {
       if (message.type() === 'error') rendererErrors.push(message.text());
     });
-    page.on('dialog', (dialog) => void dialog.accept());
+    page.on('dialog', (dialog) => {
+      dialogs.push(dialog.message());
+      void dialog.dismiss();
+    });
     await page.waitForLoadState('domcontentloaded');
 
     await page.locator('.drop-zone').click();
@@ -464,6 +470,7 @@ test('automatic calibration completes serial multi-task analysis and records zer
     expect(history.map((entry) => entry.video_name).sort()).toEqual(['batch-a.mp4', 'batch-b.mp4']);
     expect(history.every((entry) => entry.rally_count === 0 && entry.completion_kind === 'analysis')).toBe(true);
     expect(rendererErrors).toEqual([]);
+    expect(dialogs).toEqual([]);
     await testInfo.attach('multi-task-history', {
       body: Buffer.from(JSON.stringify(history, null, 2)),
       contentType: 'application/json',

--- a/worker/tests/test_predictor_roi.py
+++ b/worker/tests/test_predictor_roi.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+import threading
+
+import cv2
 import numpy as np
 import pytest
 import torch
@@ -54,6 +58,332 @@ class BrightCenterModel:
         output = torch.zeros((batch, 1, height, width), dtype=torch.float32, device=tensor.device)
         output[:, :, height // 2, width // 2] = 1.0
         return output
+
+
+@pytest.mark.parametrize("bg_mode", ["", "concat", "subtract", "subtract_concat"])
+def test_preallocated_sequence_matches_legacy_construction(bg_mode):
+    loaded = LoadedTrackNet(
+        model=BrightCenterModel(),
+        seq_len=3,
+        bg_mode=bg_mode,
+        device=torch.device("cpu"),
+    )
+    predictor = TrackNetPredictor(loaded, batch_size=1)
+    frames = [
+        np.arange(48 * 64 * 3, dtype=np.uint8).reshape(48, 64, 3),
+        np.full((48, 64, 3), 37, dtype=np.uint8),
+        np.full((48, 64, 3), 211, dtype=np.uint8),
+    ]
+    median_rgb = np.full((24, 32, 3), 91, dtype=np.uint8)
+
+    frame_channels = predictor._frame_channel_count()
+    background_channels = 3 if bg_mode == "concat" else 0
+    actual = np.empty(
+        (background_channels + len(frames) * frame_channels, 24, 32),
+        dtype=np.float32,
+    )
+    if background_channels:
+        actual[:3] = median_rgb.transpose(2, 0, 1).astype(np.float32) / 255
+    legacy_frames = []
+    for index, frame in enumerate(frames):
+        rgb = cv2.resize(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB), (32, 24))
+        if bg_mode == "subtract":
+            legacy = (
+                np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16))
+                .sum(axis=2)
+                .astype(np.float32)
+                / 255
+            )[None]
+        else:
+            rgb_chw = rgb.transpose(2, 0, 1).astype(np.float32) / 255
+            if bg_mode == "subtract_concat":
+                diff = (
+                    np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16))
+                    .sum(axis=2)
+                    .astype(np.float32)
+                    / 255
+                )
+                legacy = np.concatenate([rgb_chw, diff[None]], axis=0)
+            else:
+                legacy = rgb_chw
+        legacy_frames.append(legacy)
+        start = background_channels + index * frame_channels
+        predictor._preprocess_frame_into(
+            frame,
+            median_rgb,
+            None,
+            32,
+            24,
+            actual[start:start + frame_channels],
+        )
+    expected = np.concatenate(legacy_frames, axis=0)
+    if background_channels:
+        expected = np.concatenate([
+            median_rgb.transpose(2, 0, 1).astype(np.float32) / 255,
+            expected,
+        ])
+
+    assert actual.flags.c_contiguous
+    np.testing.assert_array_equal(actual, expected)
+
+
+class MultiFrameReader:
+    frame_count = 43
+
+    def __init__(self, value: str):
+        self.info = VideoInfo(
+            path=Path(value),
+            width=32,
+            height=24,
+            fps=30.0,
+            metadata_frame_count=self.frame_count,
+            decoded_frame_count=None,
+            duration=None,
+        )
+
+    def __iter__(self):
+        for index in range(self.frame_count):
+            yield FramePacket(
+                index=index,
+                time=index / 30,
+                time_source="fps_estimation",
+                frame_bgr=np.full((24, 32, 3), index, dtype=np.uint8),
+            )
+
+    def final_info(self):
+        return VideoInfo(
+            path=self.info.path,
+            width=self.info.width,
+            height=self.info.height,
+            fps=self.info.fps,
+            metadata_frame_count=self.info.metadata_frame_count,
+            decoded_frame_count=self.frame_count,
+            duration=self.frame_count / 30,
+            time_source_summary="fps_estimation",
+        )
+
+
+class RecordingModel:
+    def __init__(self, seq_len: int):
+        self.seq_len = seq_len
+        self.inputs = []
+
+    def __call__(self, tensor):
+        self.inputs.append(tensor.detach().cpu().clone())
+        batch, _, height, width = tensor.shape
+        return torch.zeros(
+            (batch, self.seq_len, height, width),
+            dtype=torch.float32,
+            device=tensor.device,
+        )
+
+
+def test_preallocated_batch_uses_valid_slice_and_pads_only_last_sequence(monkeypatch):
+    model = RecordingModel(seq_len=8)
+    loaded = LoadedTrackNet(
+        model=model,
+        seq_len=8,
+        bg_mode="",
+        device=torch.device("cpu"),
+    )
+    monkeypatch.setattr("ttcut_worker.predictor.StreamingVideoReader", MultiFrameReader)
+
+    points, _, _ = TrackNetPredictor(loaded, batch_size=4).predict(
+        "fake.mp4",
+        model_size=(32, 24),
+    )
+
+    assert len(points) == MultiFrameReader.frame_count
+    assert [tuple(value.shape) for value in model.inputs] == [
+        (4, 24, 24, 32),
+        (2, 24, 24, 32),
+    ]
+    final_sequence = model.inputs[1][1].numpy().reshape(8, 3, 24, 32)
+    for frame_index in range(3):
+        expected = np.float32((42 - frame_index) / 255)
+        assert final_sequence[2 - frame_index, 0, 0, 0] == expected
+    np.testing.assert_array_equal(
+        final_sequence[3:],
+        np.repeat(final_sequence[2:3], 5, axis=0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("frame_count", "valid_sequences"),
+    [(1, 1), (9, 2), (17, 3)],
+)
+def test_preallocated_final_batch_passes_only_valid_sequences(
+    monkeypatch,
+    frame_count,
+    valid_sequences,
+):
+    class PartialReader(MultiFrameReader):
+        pass
+
+    PartialReader.frame_count = frame_count
+    model = RecordingModel(seq_len=8)
+    loaded = LoadedTrackNet(
+        model=model,
+        seq_len=8,
+        bg_mode="",
+        device=torch.device("cpu"),
+    )
+    monkeypatch.setattr("ttcut_worker.predictor.StreamingVideoReader", PartialReader)
+
+    TrackNetPredictor(loaded, batch_size=4).predict(
+        "fake.mp4",
+        model_size=(32, 24),
+    )
+
+    assert [len(value) for value in model.inputs] == [valid_sequences]
+
+
+def test_cpu_predictor_never_starts_cuda_pipeline(monkeypatch):
+    model = RecordingModel(seq_len=8)
+    loaded = LoadedTrackNet(
+        model=model,
+        seq_len=8,
+        bg_mode="",
+        device=torch.device("cpu"),
+    )
+    predictor = TrackNetPredictor(loaded, batch_size=4)
+    monkeypatch.setattr("ttcut_worker.predictor.StreamingVideoReader", MultiFrameReader)
+    monkeypatch.setattr(
+        predictor,
+        "_predict_cuda_pipeline",
+        lambda *_args: pytest.fail("CPU mode started the CUDA pipeline"),
+    )
+
+    points, _, _ = predictor.predict("fake.mp4", model_size=(32, 24))
+
+    assert len(points) == MultiFrameReader.frame_count
+
+
+def _cuda_predictor_with_fake_inference(monkeypatch):
+    loaded = LoadedTrackNet(
+        model=None,
+        seq_len=8,
+        bg_mode="",
+        device=torch.device("cuda"),
+    )
+    predictor = TrackNetPredictor(loaded, batch_size=4)
+    monkeypatch.setattr("ttcut_worker.predictor.StreamingVideoReader", MultiFrameReader)
+    monkeypatch.setattr(
+        predictor,
+        "_create_pinned_cuda_resources",
+        lambda *_args: (_ for _ in ()).throw(MemoryError("pinned unavailable")),
+    )
+    monkeypatch.setattr(
+        predictor,
+        "_run_model_batch",
+        lambda inputs: np.zeros(
+            (len(inputs), loaded.seq_len, inputs.shape[2], inputs.shape[3]),
+            dtype=np.float32,
+        ),
+    )
+    return predictor
+
+
+def test_cuda_pipeline_falls_back_when_pinned_pool_cannot_be_allocated(monkeypatch):
+    predictor = _cuda_predictor_with_fake_inference(monkeypatch)
+
+    points, _, _ = predictor.predict("fake.mp4", model_size=(32, 24))
+
+    assert len(points) == MultiFrameReader.frame_count
+    assert predictor._cuda_pipeline_mode == "pageable_sync"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_pinned_cuda_resources_are_persistent_and_reusable(monkeypatch):
+    class ZeroCudaModel:
+        def __call__(self, tensor):
+            return torch.zeros(
+                (len(tensor), 8, tensor.shape[2], tensor.shape[3]),
+                dtype=torch.float32,
+                device=tensor.device,
+            )
+
+    loaded = LoadedTrackNet(
+        model=ZeroCudaModel(),
+        seq_len=8,
+        bg_mode="",
+        device=torch.device("cuda"),
+    )
+    predictor = TrackNetPredictor(loaded, batch_size=4)
+    monkeypatch.setattr("ttcut_worker.predictor.StreamingVideoReader", MultiFrameReader)
+
+    first, _, _ = predictor.predict("first.mp4", model_size=(32, 24))
+    second, _, _ = predictor.predict("second.mp4", model_size=(32, 24))
+
+    assert len(first) == len(second) == MultiFrameReader.frame_count
+    assert predictor._cuda_pipeline_mode == "pinned_async"
+    assert not [
+        thread for thread in threading.enumerate()
+        if thread.name.startswith("ttcut-tracknet-")
+    ]
+
+
+def test_cuda_pipeline_is_ordered_bounded_and_reports_postprocessed_progress(monkeypatch):
+    predictor = _cuda_predictor_with_fake_inference(monkeypatch)
+    observed_queue_sizes = []
+    original_queue_put = predictor._queue_put
+
+    def recording_queue_put(queue, value, stop_event):
+        result = original_queue_put(queue, value, stop_event)
+        observed_queue_sizes.append((queue.maxsize, queue.qsize()))
+        return result
+
+    monkeypatch.setattr(predictor, "_queue_put", recording_queue_put)
+    progress = []
+
+    points, _, _ = predictor.predict(
+        "fake.mp4",
+        model_size=(32, 24),
+        progress_callback=lambda completed, total: progress.append((completed, total)),
+    )
+
+    assert [point.frame for point in points] == list(range(MultiFrameReader.frame_count))
+    assert all(size <= capacity for capacity, size in observed_queue_sizes)
+    assert [value[0] for value in progress] == sorted(value[0] for value in progress)
+    assert progress[-1] == (MultiFrameReader.frame_count, MultiFrameReader.frame_count)
+    assert not [
+        thread for thread in threading.enumerate()
+        if thread.name.startswith("ttcut-tracknet-")
+    ]
+
+
+@pytest.mark.parametrize("failure_stage", ["producer", "gpu", "postprocessor"])
+def test_cuda_pipeline_propagates_first_error_and_joins_threads(monkeypatch, failure_stage):
+    predictor = _cuda_predictor_with_fake_inference(monkeypatch)
+    expected = RuntimeError(f"{failure_stage} failed")
+
+    def fail(*_args, **_kwargs):
+        raise expected
+
+    if failure_stage == "producer":
+        monkeypatch.setattr(predictor, "_preprocess_frame_into", fail)
+    elif failure_stage == "gpu":
+        monkeypatch.setattr(predictor, "_run_model_batch", fail)
+    else:
+        monkeypatch.setattr(predictor, "_postprocess_batch", fail)
+
+    with pytest.raises(RuntimeError) as error:
+        predictor.predict("fake.mp4", model_size=(32, 24))
+
+    assert error.value is expected
+    assert not [
+        thread for thread in threading.enumerate()
+        if thread.name.startswith("ttcut-tracknet-")
+    ]
+
+
+def test_cuda_out_of_memory_keeps_device_error_classification(monkeypatch):
+    predictor = _cuda_predictor_with_fake_inference(monkeypatch)
+
+    with pytest.raises(Exception) as error:
+        predictor._raise_device_error(RuntimeError("CUDA out of memory"))
+
+    assert getattr(error.value, "code", None) == "DEVICE_UNAVAILABLE"
 
 
 def test_predictor_uses_dynamic_roi_tensor_and_returns_source_coordinates(monkeypatch):

--- a/worker/ttcut_worker/predictor.py
+++ b/worker/ttcut_worker/predictor.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Sequence
+from queue import Empty, Full, Queue
+from threading import Event, Thread
+from typing import Any, Callable, Sequence
 
 import numpy as np
 
@@ -30,6 +32,34 @@ class PredictionStats:
     input_pixel_ratio: float = 1.0
     predictor_seconds: float = 0.0
     average_predictor_fps: float = 0.0
+
+
+@dataclass
+class _BatchSlot:
+    input_buffer: np.ndarray
+    input_tensor: Any | None = None
+    output_tensor: Any | None = None
+    input_ready: Any | None = None
+    inference_started: Any | None = None
+    inference_finished: Any | None = None
+    result_ready: Any | None = None
+    gpu_output: Any | None = None
+    ordinal: int = -1
+    valid_sequence_count: int = 0
+    packet_groups: list[list[FramePacket]] = field(default_factory=list)
+    heatmaps: np.ndarray | None = None
+    state: str = "FREE"
+
+
+@dataclass
+class _CudaPipelineResources:
+    h2d_stream: Any
+    compute_stream: Any
+    device_inputs: list[Any]
+    device_compute_done: list[Any | None]
+
+
+_END_OF_STREAM = object()
 
 
 class TrackNetPredictor:
@@ -73,58 +103,29 @@ class TrackNetPredictor:
             if self.loaded.bg_mode
             else None
         )
-        sequences: list[np.ndarray] = []
-        packets: list[FramePacket] = []
-        input_batch: list[np.ndarray] = []
-        packet_batch: list[list[FramePacket]] = []
-        predictions: list[TrajectoryPoint] = []
         total = reader.info.metadata_frame_count or 0
         if progress_callback:
             progress_callback(0, total)
-
-        for packet in reader:
-            sequences.append(self._preprocess_frame(
-                packet.frame_bgr,
+        if self.loaded.device.type == "cuda":
+            predictions = self._predict_cuda_pipeline(
+                reader,
                 median_rgb,
                 analysis_roi,
                 model_width,
                 model_height,
-            ))
-            packets.append(packet)
-            if len(sequences) == self.loaded.seq_len:
-                input_batch.append(self._assemble_sequence(sequences, median_rgb))
-                packet_batch.append(packets.copy())
-                sequences.clear()
-                packets.clear()
-            if len(input_batch) >= self.batch_size:
-                predictions.extend(self._infer_batch(
-                    input_batch,
-                    packet_batch,
-                    reader.info,
-                    analysis_roi,
-                    model_width,
-                    model_height,
-                ))
-                input_batch.clear()
-                packet_batch.clear()
-                if progress_callback:
-                    progress_callback(len(predictions), total)
-
-        if sequences:
-            actual_packets = packets.copy()
-            while len(sequences) < self.loaded.seq_len:
-                sequences.append(sequences[-1].copy())
-            input_batch.append(self._assemble_sequence(sequences, median_rgb))
-            packet_batch.append(actual_packets)
-        if input_batch:
-            predictions.extend(self._infer_batch(
-                input_batch,
-                packet_batch,
-                reader.info,
+                progress_callback,
+                total,
+            )
+        else:
+            predictions = self._predict_serial(
+                reader,
+                median_rgb,
                 analysis_roi,
                 model_width,
                 model_height,
-            ))
+                progress_callback,
+                total,
+            )
         info = reader.final_info()
         if len(predictions) != info.decoded_frame_count:
             raise VideoError("TrackNet result count does not match decoded frame count.")
@@ -142,6 +143,568 @@ class TrackNetPredictor:
             elapsed,
             len(predictions) / elapsed if elapsed else 0.0,
         )
+
+    def _create_input_buffer(
+        self,
+        median_rgb: np.ndarray | None,
+        model_width: int,
+        model_height: int,
+    ) -> np.ndarray:
+        buffer = np.empty(
+            self._input_buffer_shape(model_width, model_height),
+            dtype=np.float32,
+        )
+        self._initialize_background(buffer, median_rgb)
+        return buffer
+
+    def _input_buffer_shape(
+        self,
+        model_width: int,
+        model_height: int,
+    ) -> tuple[int, int, int, int]:
+        frame_channels = self._frame_channel_count()
+        background_channels = 3 if self.loaded.bg_mode == "concat" else 0
+        sequence_channels = background_channels + self.loaded.seq_len * frame_channels
+        return self.batch_size, sequence_channels, model_height, model_width
+
+    def _initialize_background(
+        self,
+        buffer: np.ndarray,
+        median_rgb: np.ndarray | None,
+    ) -> None:
+        background_channels = 3 if self.loaded.bg_mode == "concat" else 0
+        if background_channels:
+            if median_rgb is None:
+                raise VideoError("TrackNet background frame is unavailable.")
+            buffer[:, :background_channels] = (
+                median_rgb.transpose(2, 0, 1).astype(np.float32) / 255
+            )
+
+    def _create_pinned_cuda_resources(
+        self,
+        median_rgb: np.ndarray | None,
+        model_width: int,
+        model_height: int,
+    ) -> tuple[list[_BatchSlot], _CudaPipelineResources]:
+        torch = import_torch()
+        input_shape = self._input_buffer_shape(model_width, model_height)
+        output_shape = (
+            self.batch_size,
+            self.loaded.seq_len,
+            model_height,
+            model_width,
+        )
+        slots = []
+        for _ in range(3):
+            input_tensor = torch.empty(
+                input_shape,
+                dtype=torch.float32,
+                pin_memory=True,
+            )
+            output_tensor = torch.empty(
+                output_shape,
+                dtype=torch.float32,
+                pin_memory=True,
+            )
+            input_buffer = input_tensor.numpy()
+            self._initialize_background(input_buffer, median_rgb)
+            slots.append(_BatchSlot(
+                input_buffer=input_buffer,
+                input_tensor=input_tensor,
+                output_tensor=output_tensor,
+                input_ready=torch.cuda.Event(),
+                inference_started=torch.cuda.Event(enable_timing=True),
+                inference_finished=torch.cuda.Event(enable_timing=True),
+                result_ready=torch.cuda.Event(),
+            ))
+        resources = _CudaPipelineResources(
+            h2d_stream=torch.cuda.Stream(device=self.loaded.device),
+            compute_stream=torch.cuda.Stream(device=self.loaded.device),
+            device_inputs=[
+                torch.empty(
+                    input_shape,
+                    dtype=torch.float32,
+                    device=self.loaded.device,
+                )
+                for _ in range(2)
+            ],
+            device_compute_done=[None, None],
+        )
+        return slots, resources
+
+    def _predict_serial(
+        self,
+        reader: StreamingVideoReader,
+        median_rgb: np.ndarray | None,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        progress_callback: ProgressCallback | None,
+        total: int,
+    ) -> list[TrajectoryPoint]:
+        input_batch = self._create_input_buffer(
+            median_rgb,
+            model_width,
+            model_height,
+        )
+        packet_batch: list[list[FramePacket]] = []
+        packets: list[FramePacket] = []
+        predictions: list[TrajectoryPoint] = []
+        sequence_count = 0
+        sequence_frame_count = 0
+        frame_channels = self._frame_channel_count()
+        background_channels = 3 if self.loaded.bg_mode == "concat" else 0
+
+        for packet in reader:
+            self._write_packet(
+                input_batch,
+                sequence_count,
+                sequence_frame_count,
+                packet,
+                median_rgb,
+                analysis_roi,
+                model_width,
+                model_height,
+                frame_channels,
+                background_channels,
+            )
+            packets.append(packet)
+            sequence_frame_count += 1
+            if sequence_frame_count == self.loaded.seq_len:
+                packet_batch.append(packets.copy())
+                packets.clear()
+                sequence_count += 1
+                sequence_frame_count = 0
+            if sequence_count == self.batch_size:
+                predictions.extend(self._infer_batch(
+                    input_batch[:sequence_count],
+                    packet_batch,
+                    reader.info,
+                    analysis_roi,
+                    model_width,
+                    model_height,
+                ))
+                packet_batch.clear()
+                sequence_count = 0
+                if progress_callback:
+                    progress_callback(len(predictions), total)
+
+        if sequence_frame_count:
+            self._pad_partial_sequence(
+                input_batch,
+                sequence_count,
+                sequence_frame_count,
+                frame_channels,
+                background_channels,
+            )
+            packet_batch.append(packets.copy())
+            sequence_count += 1
+        if sequence_count:
+            predictions.extend(self._infer_batch(
+                input_batch[:sequence_count],
+                packet_batch,
+                reader.info,
+                analysis_roi,
+                model_width,
+                model_height,
+            ))
+        return predictions
+
+    def _predict_cuda_pipeline(
+        self,
+        reader: StreamingVideoReader,
+        median_rgb: np.ndarray | None,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        progress_callback: ProgressCallback | None,
+        total: int,
+    ) -> list[TrajectoryPoint]:
+        free_slots: Queue[Any] = Queue(maxsize=3)
+        ready_slots: Queue[Any] = Queue(maxsize=2)
+        result_slots: Queue[Any] = Queue(maxsize=2)
+        first_error: Queue[BaseException] = Queue(maxsize=1)
+        stop_event = Event()
+        predictions: list[TrajectoryPoint] = []
+        resources: _CudaPipelineResources | None
+        try:
+            slots, resources = self._create_pinned_cuda_resources(
+                median_rgb,
+                model_width,
+                model_height,
+            )
+            self._cuda_pipeline_mode = "pinned_async"
+        except (MemoryError, RuntimeError):
+            resources = None
+            slots = [
+                _BatchSlot(self._create_input_buffer(
+                    median_rgb,
+                    model_width,
+                    model_height,
+                ))
+                for _ in range(3)
+            ]
+            self._cuda_pipeline_mode = "pageable_sync"
+        for slot in slots:
+            free_slots.put(slot)
+
+        producer = Thread(
+            target=self._produce_cuda_slots,
+            name="ttcut-tracknet-producer",
+            args=(
+                reader,
+                median_rgb,
+                analysis_roi,
+                model_width,
+                model_height,
+                free_slots,
+                ready_slots,
+                first_error,
+                stop_event,
+            ),
+        )
+        postprocessor = Thread(
+            target=self._postprocess_cuda_slots,
+            name="ttcut-tracknet-postprocessor",
+            args=(
+                result_slots,
+                free_slots,
+                predictions,
+                reader.info,
+                analysis_roi,
+                model_width,
+                model_height,
+                progress_callback,
+                total,
+                first_error,
+                stop_event,
+            ),
+        )
+        producer.start()
+        postprocessor.start()
+        try:
+            self._consume_cuda_slots(
+                ready_slots,
+                result_slots,
+                resources,
+                first_error,
+                stop_event,
+            )
+        except BaseException as exc:
+            self._record_pipeline_error(first_error, stop_event, exc)
+        finally:
+            if not first_error.empty():
+                stop_event.set()
+            producer.join()
+            postprocessor.join()
+            if resources is not None:
+                torch = import_torch()
+                try:
+                    torch.cuda.synchronize(self.loaded.device)
+                except BaseException as exc:
+                    self._record_pipeline_error(first_error, stop_event, exc)
+        if not first_error.empty():
+            raise first_error.get()
+        return predictions
+
+    def _produce_cuda_slots(
+        self,
+        reader: StreamingVideoReader,
+        median_rgb: np.ndarray | None,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        free_slots: Queue[Any],
+        ready_slots: Queue[Any],
+        first_error: Queue[BaseException],
+        stop_event: Event,
+    ) -> None:
+        current: _BatchSlot | None = None
+        packets: list[FramePacket] = []
+        sequence_frame_count = 0
+        ordinal = 0
+        frame_channels = self._frame_channel_count()
+        background_channels = 3 if self.loaded.bg_mode == "concat" else 0
+        try:
+            for packet in reader:
+                if current is None:
+                    value = self._queue_get(free_slots, stop_event)
+                    if value is None:
+                        return
+                    current = value
+                    self._transition_slot(current, "FREE", "FILLING")
+                    current.ordinal = ordinal
+                    current.valid_sequence_count = 0
+                    current.packet_groups.clear()
+                    current.heatmaps = None
+                self._write_packet(
+                    current.input_buffer,
+                    current.valid_sequence_count,
+                    sequence_frame_count,
+                    packet,
+                    median_rgb,
+                    analysis_roi,
+                    model_width,
+                    model_height,
+                    frame_channels,
+                    background_channels,
+                )
+                packets.append(packet)
+                sequence_frame_count += 1
+                if sequence_frame_count == self.loaded.seq_len:
+                    current.packet_groups.append(packets.copy())
+                    packets.clear()
+                    current.valid_sequence_count += 1
+                    sequence_frame_count = 0
+                if current.valid_sequence_count == self.batch_size:
+                    self._transition_slot(current, "FILLING", "READY")
+                    if not self._queue_put(ready_slots, current, stop_event):
+                        return
+                    ordinal += 1
+                    current = None
+
+            if current is not None and sequence_frame_count:
+                self._pad_partial_sequence(
+                    current.input_buffer,
+                    current.valid_sequence_count,
+                    sequence_frame_count,
+                    frame_channels,
+                    background_channels,
+                )
+                current.packet_groups.append(packets.copy())
+                current.valid_sequence_count += 1
+            if current is not None and current.valid_sequence_count:
+                self._transition_slot(current, "FILLING", "READY")
+                if not self._queue_put(ready_slots, current, stop_event):
+                    return
+            self._queue_put(ready_slots, _END_OF_STREAM, stop_event)
+        except BaseException as exc:
+            self._record_pipeline_error(first_error, stop_event, exc)
+
+    def _consume_cuda_slots(
+        self,
+        ready_slots: Queue[Any],
+        result_slots: Queue[Any],
+        resources: _CudaPipelineResources | None,
+        first_error: Queue[BaseException],
+        stop_event: Event,
+    ) -> None:
+        try:
+            while True:
+                value = self._queue_get(ready_slots, stop_event)
+                if value is None:
+                    return
+                if value is _END_OF_STREAM:
+                    self._queue_put(result_slots, _END_OF_STREAM, stop_event)
+                    return
+                slot: _BatchSlot = value
+                self._transition_slot(slot, "READY", "GPU_RUNNING")
+                if resources is None:
+                    slot.heatmaps = self._run_model_batch(
+                        slot.input_buffer[:slot.valid_sequence_count],
+                    )
+                else:
+                    self._enqueue_async_cuda_slot(slot, resources)
+                self._transition_slot(slot, "GPU_RUNNING", "RESULT_READY")
+                if not self._queue_put(result_slots, slot, stop_event):
+                    return
+        except BaseException as exc:
+            self._record_pipeline_error(first_error, stop_event, exc)
+
+    def _enqueue_async_cuda_slot(
+        self,
+        slot: _BatchSlot,
+        resources: _CudaPipelineResources,
+    ) -> None:
+        torch = import_torch()
+        if (
+            slot.input_tensor is None
+            or slot.output_tensor is None
+            or slot.input_ready is None
+            or slot.inference_started is None
+            or slot.inference_finished is None
+            or slot.result_ready is None
+        ):
+            raise RuntimeError("TrackNet pinned CUDA slot is incomplete.")
+        device_index = slot.ordinal % len(resources.device_inputs)
+        device_input = resources.device_inputs[device_index]
+        valid = slot.valid_sequence_count
+        try:
+            with torch.cuda.stream(resources.h2d_stream):
+                previous_compute = resources.device_compute_done[device_index]
+                if previous_compute is not None:
+                    resources.h2d_stream.wait_event(previous_compute)
+                device_input[:valid].copy_(
+                    slot.input_tensor[:valid],
+                    non_blocking=True,
+                )
+                slot.input_ready.record(resources.h2d_stream)
+            with torch.cuda.stream(resources.compute_stream):
+                resources.compute_stream.wait_event(slot.input_ready)
+                slot.inference_started.record(resources.compute_stream)
+                with torch.no_grad():
+                    slot.gpu_output = self.loaded.model(device_input[:valid])
+                slot.inference_finished.record(resources.compute_stream)
+                compute_done = torch.cuda.Event()
+                compute_done.record(resources.compute_stream)
+                resources.device_compute_done[device_index] = compute_done
+                slot.output_tensor[:valid].copy_(
+                    slot.gpu_output,
+                    non_blocking=True,
+                )
+                slot.result_ready.record(resources.compute_stream)
+        except Exception as exc:
+            self._raise_device_error(exc)
+
+    def _postprocess_cuda_slots(
+        self,
+        result_slots: Queue[Any],
+        free_slots: Queue[Any],
+        predictions: list[TrajectoryPoint],
+        info: VideoInfo,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        progress_callback: ProgressCallback | None,
+        total: int,
+        first_error: Queue[BaseException],
+        stop_event: Event,
+    ) -> None:
+        expected_ordinal = 0
+        try:
+            while True:
+                value = self._queue_get(result_slots, stop_event)
+                if value is None:
+                    return
+                if value is _END_OF_STREAM:
+                    return
+                slot: _BatchSlot = value
+                if slot.ordinal != expected_ordinal:
+                    raise RuntimeError("TrackNet pipeline batch order changed.")
+                expected_ordinal += 1
+                self._transition_slot(slot, "RESULT_READY", "POSTPROCESSING")
+                if slot.result_ready is not None:
+                    try:
+                        slot.result_ready.synchronize()
+                    except Exception as exc:
+                        self._raise_device_error(exc)
+                    self._model_inference_seconds += (
+                        slot.inference_started.elapsed_time(
+                            slot.inference_finished,
+                        )
+                        / 1000
+                    )
+                    heatmaps = slot.output_tensor[
+                        :slot.valid_sequence_count
+                    ].numpy()
+                elif slot.heatmaps is not None:
+                    heatmaps = slot.heatmaps
+                else:
+                    raise RuntimeError("TrackNet pipeline result is unavailable.")
+                predictions.extend(self._postprocess_batch(
+                    heatmaps,
+                    slot.packet_groups,
+                    info,
+                    analysis_roi,
+                    model_width,
+                    model_height,
+                ))
+                if progress_callback:
+                    progress_callback(len(predictions), total)
+                slot.heatmaps = None
+                slot.gpu_output = None
+                slot.packet_groups.clear()
+                self._transition_slot(slot, "POSTPROCESSING", "FREE")
+                if not self._queue_put(free_slots, slot, stop_event):
+                    return
+        except BaseException as exc:
+            self._record_pipeline_error(first_error, stop_event, exc)
+
+    @staticmethod
+    def _queue_get(queue: Queue[Any], stop_event: Event) -> Any | None:
+        while not stop_event.is_set():
+            try:
+                return queue.get(timeout=0.05)
+            except Empty:
+                continue
+        return None
+
+    @staticmethod
+    def _queue_put(queue: Queue[Any], value: Any, stop_event: Event) -> bool:
+        while not stop_event.is_set():
+            try:
+                queue.put(value, timeout=0.05)
+                return True
+            except Full:
+                continue
+        return False
+
+    @staticmethod
+    def _record_pipeline_error(
+        first_error: Queue[BaseException],
+        stop_event: Event,
+        error: BaseException,
+    ) -> None:
+        try:
+            first_error.put_nowait(error)
+        except Full:
+            pass
+        stop_event.set()
+
+    @staticmethod
+    def _transition_slot(slot: _BatchSlot, expected: str, next_state: str) -> None:
+        if slot.state != expected:
+            raise RuntimeError(
+                f"TrackNet pipeline slot transition {slot.state} -> {next_state} "
+                f"expected {expected}.",
+            )
+        slot.state = next_state
+
+    def _write_packet(
+        self,
+        input_buffer: np.ndarray,
+        sequence_index: int,
+        frame_index: int,
+        packet: FramePacket,
+        median_rgb: np.ndarray | None,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        frame_channels: int,
+        background_channels: int,
+    ) -> None:
+        channel_start = background_channels + frame_index * frame_channels
+        self._preprocess_frame_into(
+            packet.frame_bgr,
+            median_rgb,
+            analysis_roi,
+            model_width,
+            model_height,
+            input_buffer[
+                sequence_index,
+                channel_start:channel_start + frame_channels,
+            ],
+        )
+
+    def _pad_partial_sequence(
+        self,
+        input_buffer: np.ndarray,
+        sequence_index: int,
+        frame_count: int,
+        frame_channels: int,
+        background_channels: int,
+    ) -> None:
+        source_start = background_channels + (frame_count - 1) * frame_channels
+        last_frame = input_buffer[
+            sequence_index,
+            source_start:source_start + frame_channels,
+        ].copy()
+        for frame_index in range(frame_count, self.loaded.seq_len):
+            channel_start = background_channels + frame_index * frame_channels
+            input_buffer[
+                sequence_index,
+                channel_start:channel_start + frame_channels,
+            ] = last_frame
 
     def _estimate_median(
         self,
@@ -194,6 +757,13 @@ class TrackNetPredictor:
             raise AnalysisRoiError("The analysis ROI produced an empty frame.")
         return cropped
 
+    def _frame_channel_count(self) -> int:
+        if self.loaded.bg_mode == "subtract":
+            return 1
+        if self.loaded.bg_mode == "subtract_concat":
+            return 4
+        return 3
+
     def _preprocess_frame(
         self,
         frame_bgr,
@@ -202,6 +772,29 @@ class TrackNetPredictor:
         model_width: int,
         model_height: int,
     ) -> np.ndarray:
+        output = np.empty(
+            (self._frame_channel_count(), model_height, model_width),
+            dtype=np.float32,
+        )
+        self._preprocess_frame_into(
+            frame_bgr,
+            median_rgb,
+            analysis_roi,
+            model_width,
+            model_height,
+            output,
+        )
+        return output
+
+    def _preprocess_frame_into(
+        self,
+        frame_bgr,
+        median_rgb: np.ndarray | None,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+        output: np.ndarray,
+    ) -> None:
         import cv2
 
         cropped = self._crop_frame(frame_bgr, analysis_roi)
@@ -210,32 +803,44 @@ class TrackNetPredictor:
             (model_width, model_height),
         )
         if self.loaded.bg_mode == "subtract":
-            return (np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16)).sum(axis=2).astype(np.float32) / 255)[None]
-        rgb_chw = rgb.transpose(2, 0, 1).astype(np.float32) / 255
+            output[0] = (
+                np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16))
+                .sum(axis=2)
+                .astype(np.float32)
+                / 255
+            )
+            return
+        output[:3] = rgb.transpose(2, 0, 1).astype(np.float32) / 255
         if self.loaded.bg_mode == "subtract_concat":
-            diff = np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16)).sum(axis=2).astype(np.float32) / 255
-            return np.concatenate([rgb_chw, diff[None]], axis=0)
-        return rgb_chw
-
-    def _assemble_sequence(self, frames: Sequence[np.ndarray], median_rgb: np.ndarray | None) -> np.ndarray:
-        assembled = np.concatenate(frames, axis=0)
-        if self.loaded.bg_mode == "concat":
-            median = median_rgb.transpose(2, 0, 1).astype(np.float32) / 255
-            assembled = np.concatenate([median, assembled], axis=0)
-        return np.ascontiguousarray(assembled, dtype=np.float32)
+            output[3] = (
+                np.abs(rgb.astype(np.int16) - median_rgb.astype(np.int16))
+                .sum(axis=2)
+                .astype(np.float32)
+                / 255
+            )
 
     def _infer_batch(
         self,
-        inputs: Sequence[np.ndarray],
+        inputs: np.ndarray,
         packet_groups: Sequence[Sequence[FramePacket]],
         info: VideoInfo,
         analysis_roi: AnalysisRoi | None,
         model_width: int,
         model_height: int,
     ) -> list[TrajectoryPoint]:
+        return self._postprocess_batch(
+            self._run_model_batch(inputs),
+            packet_groups,
+            info,
+            analysis_roi,
+            model_width,
+            model_height,
+        )
+
+    def _run_model_batch(self, inputs: np.ndarray) -> np.ndarray:
         torch = import_torch()
         try:
-            tensor = torch.from_numpy(np.stack(inputs)).float().to(self.loaded.device)
+            tensor = torch.from_numpy(inputs).float().to(self.loaded.device)
             if self.loaded.device.type == "cuda":
                 torch.cuda.synchronize(self.loaded.device)
             inference_started = time.perf_counter()
@@ -246,11 +851,29 @@ class TrackNetPredictor:
             self._model_inference_seconds += time.perf_counter() - inference_started
             heatmaps = model_output.detach().cpu().numpy()
         except Exception as exc:
-            if "out of memory" in str(exc).lower():
-                if torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-                raise DeviceError("CUDA ran out of memory; use CPU mode or a smaller batch.") from exc
-            raise
+            self._raise_device_error(exc)
+        return heatmaps
+
+    @staticmethod
+    def _raise_device_error(error: Exception) -> None:
+        if "out of memory" in str(error).lower():
+            torch = import_torch()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            raise DeviceError(
+                "CUDA ran out of memory; use CPU mode or a smaller batch.",
+            ) from error
+        raise error
+
+    def _postprocess_batch(
+        self,
+        heatmaps: np.ndarray,
+        packet_groups: Sequence[Sequence[FramePacket]],
+        info: VideoInfo,
+        analysis_roi: AnalysisRoi | None,
+        model_width: int,
+        model_height: int,
+    ) -> list[TrajectoryPoint]:
         output: list[TrajectoryPoint] = []
         if analysis_roi is None:
             origin_x, origin_y = 0.0, 0.0


### PR DESCRIPTION
## What
- replace repeated TrackNet batch allocations with reusable bounded slots
- add a CUDA-only three-stage pipeline with pinned host buffers, asynchronous transfers, and CUDA event timing
- preserve the serial CPU fallback and existing worker/UI protocols
- map automatic calibration to the first 5% of progress and analysis to the remaining 95%
- dismiss unreliable auto-calibration notices after 3 seconds and remove the multi-task test confirmation

## Why
The CUDA predictor previously serialized CPU preparation, GPU inference, and CPU post-processing while repeatedly reallocating large sequence batches. The UI also left the auto-calibration warning visible indefinitely and reported calibration/analysis progress without the requested weighting.

## Impact and risk controls
- model, batch size, ROI, detection rules, Electron IPC, and Worker JSONL remain unchanged
- queues and buffer slots are bounded; CPU mode remains serial
- first-error propagation, cancellation checks, and pinned-memory fallback preserve failure behavior
- no new Windows APIs, runtime dependencies, version gates, signing, release, or version changes

## Verification
- focused predictor and workflow tests passed
- full Python Worker test suite passed
- TypeScript typecheck passed
- full Vitest suite passed: 81 passed, 8 skipped
- Windows x64 package build passed
- real Electron CUDA analysis/export E2E passed
- real Electron multi-task E2E passed with zero confirmation dialogs
- git diff whitespace check passed

The performance report in this PR records the baseline and each optimization checkpoint, including output-equivalence results and measurement limitations.