### PR TITLE
Fix Win7 installer PowerShell 2 compatibility

### DIFF
--- a/build/installer/check-install-space.ps1
+++ b/build/installer/check-install-space.ps1
@@ -1,0 +1,62 @@
+param(
+  [int64]$EstimatedSizeKb
+)
+
+$ErrorActionPreference = 'Stop'
+$safetyReserveBytes = [int64]536870912
+
+function Get-TTcutTreeBytes {
+  param([string]$Root)
+
+  if ([string]::IsNullOrEmpty($Root) -or
+      -not (Test-Path -LiteralPath $Root -PathType Container)) {
+    return [int64]0
+  }
+
+  $total = [int64]0
+  # PowerShell 2 has no -File switch. Filter the FileInfo objects instead.
+  $files = @(
+    Get-ChildItem -LiteralPath $Root -Recurse -Force -ErrorAction Stop |
+      Where-Object { -not $_.PSIsContainer }
+  )
+  foreach ($file in $files) {
+    $total += [int64]$file.Length
+  }
+  return $total
+}
+
+try {
+  if ($EstimatedSizeKb -le 0) {
+    exit 2
+  }
+
+  $installRoot = [string]$env:TTCUT_INSTALLER_ROOT
+  if ([string]::IsNullOrEmpty($installRoot)) {
+    exit 2
+  }
+
+  $driveRoot = [IO.Path]::GetPathRoot($installRoot)
+  if ([string]::IsNullOrEmpty($driveRoot)) {
+    exit 2
+  }
+
+  # Construct the object through New-Object for the PowerShell 2 runtime.
+  $drive = New-Object -TypeName System.IO.DriveInfo -ArgumentList @($driveRoot)
+  $required = ([int64]$EstimatedSizeKb * [int64]1024)
+  $required += Get-TTcutTreeBytes ([string]$env:TTCUT_INSTALLER_LEGACY)
+
+  $legacyUpdate = [string]$env:TTCUT_INSTALLER_LEGACY_APP
+  if (-not [string]::IsNullOrEmpty($legacyUpdate) -and
+      (Test-Path -LiteralPath $legacyUpdate -PathType Leaf)) {
+    $required += Get-TTcutTreeBytes (Split-Path -Parent $legacyUpdate)
+  }
+
+  $required += $safetyReserveBytes
+  if ([int64]$drive.AvailableFreeSpace -lt $required) {
+    exit 1
+  }
+  exit 0
+} catch {
+  # 1 means a real low-space result; 2 means the check itself failed.
+  exit 2
+}

--- a/build/installer/choose-default-root.ps1
+++ b/build/installer/choose-default-root.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = 'Stop'
+
+try {
+  $systemRoot = [IO.Path]::GetPathRoot([string]$env:SystemRoot)
+  if ($systemRoot) {
+    $systemRoot = $systemRoot.TrimEnd('\')
+  }
+
+  # Get-WmiObject is available in the PowerShell shipped with Windows 7.
+  # A failed probe must never become a path value in the NSIS edit control.
+  $disks = @(
+    Get-WmiObject -Class Win32_LogicalDisk -ErrorAction Stop |
+      Where-Object {
+        $_.DeviceID -and
+        $_.DeviceID -ne $systemRoot -and
+        $_.FreeSpace -ne $null
+      } |
+      Sort-Object FreeSpace -Descending
+  )
+} catch {
+  exit 1
+}
+
+foreach ($disk in $disks) {
+  $candidate = Join-Path ([string]$disk.DeviceID) 'TTcut'
+  $created = $false
+
+  try {
+    if (-not (Test-Path -LiteralPath $candidate)) {
+      New-Item -ItemType Directory -Path $candidate -ErrorAction Stop | Out-Null
+      $created = $true
+    }
+
+    $entries = @(Get-ChildItem -LiteralPath $candidate -Force -ErrorAction Stop)
+    if ($entries.Count -gt 0) {
+      if ($created) {
+        Remove-Item -LiteralPath $candidate -Force -ErrorAction SilentlyContinue
+      }
+      continue
+    }
+
+    $probe = Join-Path $candidate '.ttcut-write-test'
+    [IO.File]::WriteAllText($probe, '')
+    Remove-Item -LiteralPath $probe -Force -ErrorAction Stop
+    if ($created) {
+      Remove-Item -LiteralPath $candidate -Force -ErrorAction Stop
+    }
+
+    # Emit only the successful path, without a formatting newline.
+    [Console]::Write($candidate)
+    exit 0
+  } catch {
+    if ($created -and (Test-Path -LiteralPath $candidate)) {
+      Remove-Item -LiteralPath $candidate -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
+exit 1

--- a/build/installer/close-legacy-processes.ps1
+++ b/build/installer/close-legacy-processes.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop'
 
 $componentRoot = $env:TTCUT_INSTALLER_LEGACY
-if ([string]::IsNullOrWhiteSpace($componentRoot)) {
+if (-not $componentRoot -or $componentRoot.Trim().Length -eq 0) {
   exit 0
 }
 
@@ -12,7 +12,8 @@ $legacyAppPrefix = [IO.Path]::GetFullPath(
 
 function Get-TTcutBusyProcess {
   @(
-    Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+    # Get-WmiObject is available in the PowerShell shipped with Windows 7.
+    Get-WmiObject Win32_Process -ErrorAction SilentlyContinue |
       Where-Object {
         $_.ExecutablePath -and (
           (

--- a/build/installer/commit-install-registration.ps1
+++ b/build/installer/commit-install-registration.ps1
@@ -1,22 +1,31 @@
 param(
-  [Parameter(Mandatory = $true)]
   [string]$InstallRoot,
 
-  [Parameter(Mandatory = $true)]
   [string]$AppGuid,
 
-  [Parameter(Mandatory = $true)]
   [string]$Version,
 
-  [Parameter(Mandatory = $true)]
-  [ValidateSet(0, 1)]
   [int]$DesktopShortcut,
 
-  [Parameter(Mandatory = $true)]
   [string]$ReportPath
 )
 
 $ErrorActionPreference = 'Stop'
+
+function ConvertTo-TTcutJsonString {
+  param([string]$Value)
+
+  $escaped = ''
+  if ($null -ne $Value) {
+    $escaped = [string]$Value
+  }
+  $escaped = $escaped.Replace('\', '\\')
+  $escaped = $escaped.Replace('"', '\"')
+  $escaped = $escaped.Replace("`r", '\r')
+  $escaped = $escaped.Replace("`n", '\n')
+  $escaped = $escaped.Replace("`t", '\t')
+  return '"' + $escaped + '"'
+}
 
 function Write-TTcutRegistrationReport {
   param(
@@ -24,22 +33,23 @@ function Write-TTcutRegistrationReport {
     [string]$ErrorCode
   )
 
-  $report = [ordered]@{
-    schema_version = 1
-    status = $Status
-    install_root = $InstallRoot
-    app_guid = $AppGuid
-    version = $Version
-    desktop_shortcut = $DesktopShortcut
-    error_code = $ErrorCode
-  }
+  $fields = @(
+    '"schema_version":1'
+    ('"status":' + (ConvertTo-TTcutJsonString $Status))
+    ('"install_root":' + (ConvertTo-TTcutJsonString $InstallRoot))
+    ('"app_guid":' + (ConvertTo-TTcutJsonString $AppGuid))
+    ('"version":' + (ConvertTo-TTcutJsonString $Version))
+    ('"desktop_shortcut":' + [string]$DesktopShortcut)
+    ('"error_code":' + (ConvertTo-TTcutJsonString $ErrorCode))
+  )
+  $report = '{' + ($fields -join ',') + '}'
 
   $reportDirectory = Split-Path -Parent $ReportPath
   if ($reportDirectory) {
     New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
   }
-  $report | ConvertTo-Json -Compress |
-    Set-Content -LiteralPath $ReportPath -Encoding UTF8
+  $utf8 = New-Object -TypeName System.Text.UTF8Encoding
+  [IO.File]::WriteAllText($ReportPath, $report, $utf8)
 }
 
 try {

--- a/build/installer/compare-versions.ps1
+++ b/build/installer/compare-versions.ps1
@@ -1,8 +1,6 @@
 param(
-  [Parameter(Mandatory = $true)]
   [string]$InstalledVersion,
 
-  [Parameter(Mandatory = $true)]
   [string]$CandidateVersion
 )
 
@@ -19,12 +17,20 @@ function ConvertFrom-SemVer {
     return $null
   }
 
-  return [pscustomobject]@{
-    major = [System.Numerics.BigInteger]::Parse($match.Groups[1].Value)
-    minor = [System.Numerics.BigInteger]::Parse($match.Groups[2].Value)
-    patch = [System.Numerics.BigInteger]::Parse($match.Groups[3].Value)
+  return New-Object -TypeName PSObject -Property @{
+    major = $match.Groups[1].Value
+    minor = $match.Groups[2].Value
+    patch = $match.Groups[3].Value
     prerelease = if ($match.Groups[4].Success) { @($match.Groups[4].Value.Split('.')) } else { @() }
   }
+}
+
+function Compare-NumericString {
+  param([string]$Left, [string]$Right)
+
+  if ($Left.Length -lt $Right.Length) { return -1 }
+  if ($Left.Length -gt $Right.Length) { return 1 }
+  return [string]::CompareOrdinal($Left, $Right)
 }
 
 function Compare-SemVerIdentifier {
@@ -33,10 +39,7 @@ function Compare-SemVerIdentifier {
   $leftNumeric = $Left -match '^(0|[1-9]\d*)$'
   $rightNumeric = $Right -match '^(0|[1-9]\d*)$'
   if ($leftNumeric -and $rightNumeric) {
-    return [System.Numerics.BigInteger]::Compare(
-      [System.Numerics.BigInteger]::Parse($Left),
-      [System.Numerics.BigInteger]::Parse($Right)
-    )
+    return Compare-NumericString $Left $Right
   }
   if ($leftNumeric) { return -1 }
   if ($rightNumeric) { return 1 }
@@ -47,20 +50,22 @@ function Compare-SemVer {
   param($Left, $Right)
 
   foreach ($part in @('major', 'minor', 'patch')) {
-    $comparison = [System.Numerics.BigInteger]::Compare($Left.$part, $Right.$part)
+    $comparison = Compare-NumericString $Left.$part $Right.$part
     if ($comparison -ne 0) { return $comparison }
   }
 
-  if ($Left.prerelease.Count -eq 0 -and $Right.prerelease.Count -eq 0) { return 0 }
-  if ($Left.prerelease.Count -eq 0) { return 1 }
-  if ($Right.prerelease.Count -eq 0) { return -1 }
+  $leftPrerelease = @($Left.prerelease | Where-Object { $null -ne $_ })
+  $rightPrerelease = @($Right.prerelease | Where-Object { $null -ne $_ })
+  if ($leftPrerelease.Count -eq 0 -and $rightPrerelease.Count -eq 0) { return 0 }
+  if ($leftPrerelease.Count -eq 0) { return 1 }
+  if ($rightPrerelease.Count -eq 0) { return -1 }
 
-  $count = [Math]::Min($Left.prerelease.Count, $Right.prerelease.Count)
+  $count = [Math]::Min($leftPrerelease.Count, $rightPrerelease.Count)
   for ($index = 0; $index -lt $count; $index += 1) {
-    $comparison = Compare-SemVerIdentifier $Left.prerelease[$index] $Right.prerelease[$index]
+    $comparison = Compare-SemVerIdentifier $leftPrerelease[$index] $rightPrerelease[$index]
     if ($comparison -ne 0) { return $comparison }
   }
-  return $Left.prerelease.Count.CompareTo($Right.prerelease.Count)
+  return $leftPrerelease.Count.CompareTo($rightPrerelease.Count)
 }
 
 try {

--- a/build/installer/finalize-legacy-install.ps1
+++ b/build/installer/finalize-legacy-install.ps1
@@ -1,14 +1,10 @@
 param(
-  [Parameter(Mandatory = $true)]
   [string]$LegacyUpdateExe,
 
-  [Parameter(Mandatory = $true)]
   [string]$LegacyInstallRoot,
 
-  [Parameter(Mandatory = $true)]
   [string]$BackupRoot,
 
-  [Parameter(Mandatory = $true)]
   [string]$ReportPath
 )
 
@@ -245,7 +241,8 @@ try {
       $legacyPrefix = $expectedRoot + '\'
       for ($attempt = 0; $attempt -lt 20; $attempt += 1) {
         $busy = @(
-          Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+          # Get-WmiObject is available in the PowerShell shipped with Windows 7.
+          Get-WmiObject Win32_Process -ErrorAction SilentlyContinue |
             Where-Object { $_.ExecutablePath -and $_.ExecutablePath.StartsWith($legacyPrefix, [StringComparison]::OrdinalIgnoreCase) }
         )
         if ($busy.Count -eq 0 -and (Test-Path -LiteralPath $expectedRoot)) {

--- a/build/installer/installer.nsh
+++ b/build/installer/installer.nsh
@@ -43,6 +43,8 @@ LangString TTCUT_PATH_NOT_EMPTY 1033 "Choose an empty folder, or the existing TT
 LangString TTCUT_PATH_NOT_EMPTY 2052 "请选择空文件夹，或已经安装的 TTcut 位置。"
 LangString TTCUT_SPACE_REQUIRED 1033 "The selected drive does not have enough free space for TTcut and its components."
 LangString TTCUT_SPACE_REQUIRED 2052 "所选磁盘的可用空间不足以安装 TTcut 及其组件。"
+LangString TTCUT_SPACE_CHECK_FAILED 1033 "The installer's free-space check could not be completed. Choose another location and try again."
+LangString TTCUT_SPACE_CHECK_FAILED 2052 "无法完成安装器的磁盘空间检查，请选择其他位置后重试。"
 LangString TTCUT_PATH_WRITE 2052 "所选安装位置不可写。"
 LangString TTCUT_MIGRATION_FAILED 1033 "Component migration failed. The old installation and components were left unchanged."
 LangString TTCUT_MIGRATION_FAILED 2052 "组件迁移失败，旧程序和旧组件保持不变。"
@@ -125,11 +127,21 @@ FunctionEnd
 
 Function TTcutChooseDefaultRoot
   StrCpy $TTcutRoot ""
-  nsExec::ExecToStack 'powershell.exe -NoProfile -NonInteractive -Command "$$s=[IO.Path]::GetPathRoot($$env:SystemRoot).TrimEnd(''\'');Get-CimInstance Win32_LogicalDisk|Where-Object DeviceID -ne $$s|Sort-Object {[int64]$$_.FreeSpace} -Descending|ForEach-Object{$$p=$$_.DeviceID+''\TTcut'';try{$$made=!(Test-Path -LiteralPath $$p);if($$made){New-Item -ItemType Directory -Path $$p -ErrorAction Stop|Out-Null}elseif(Get-ChildItem -LiteralPath $$p -Force -ErrorAction Stop|Select-Object -First 1){return};$$t=Join-Path $$p ''.ttcut-write-test'';[IO.File]::WriteAllText($$t,'''');Remove-Item -LiteralPath $$t -Force;if($$made){Remove-Item -LiteralPath $$p -Force};Write-Output $$p;break}catch{if($$made -and (Test-Path -LiteralPath $$p)){Remove-Item -LiteralPath $$p -Force -ErrorAction SilentlyContinue}}}"'
+  InitPluginsDir
+  SetOutPath "$PLUGINSDIR"
+  File /oname=choose-default-root.ps1 "${PROJECT_DIR}\build\installer\choose-default-root.ps1"
+  nsExec::ExecToStack 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\choose-default-root.ps1"'
   Pop $0
   Pop $1
   ${If} $0 == 0
-    StrCpy $TTcutRoot $1
+    ; Never copy an error record (or a diagnostic line) into the path field.
+    StrLen $2 $1
+    ${If} $2 >= 3
+      StrCpy $3 $1 1 1
+      ${If} $3 == ":"
+        StrCpy $TTcutRoot $1
+      ${EndIf}
+    ${EndIf}
   ${EndIf}
 FunctionEnd
 
@@ -378,11 +390,17 @@ Function TTcutOptionsLeave
     System::Call 'kernel32::SetEnvironmentVariableW(w "TTCUT_INSTALLER_LEGACY", w "$TTcutLegacyComponents")i.r1'
   ${EndIf}
   System::Call 'kernel32::SetEnvironmentVariableW(w "TTCUT_INSTALLER_LEGACY_APP", w "$TTcutLegacyUninstall")i.r1'
-  nsExec::ExecToStack 'powershell.exe -NoProfile -NonInteractive -Command "$$root=$$env:TTCUT_INSTALLER_ROOT;$$legacy=$$env:TTCUT_INSTALLER_LEGACY;$$legacyUpdate=$$env:TTCUT_INSTALLER_LEGACY_APP;$$free=[IO.DriveInfo]::new([IO.Path]::GetPathRoot($$root)).AvailableFreeSpace;$$legacyBytes=0;$$legacyAppBytes=0;if(Test-Path -LiteralPath $$legacy){$$legacyBytes=(Get-ChildItem -LiteralPath $$legacy -File -Recurse -Force -ErrorAction Stop|Measure-Object Length -Sum).Sum};if($$legacyUpdate -and (Test-Path -LiteralPath $$legacyUpdate)){$$legacyApp=Split-Path -Parent $$legacyUpdate;$$legacyAppBytes=(Get-ChildItem -LiteralPath $$legacyApp -File -Recurse -Force -ErrorAction Stop|Measure-Object Length -Sum).Sum};$$required=[int64]${ESTIMATED_SIZE}*1024+[int64]$$legacyBytes+[int64]$$legacyAppBytes+536870912;if($$free -lt $$required){exit 1}"'
+  InitPluginsDir
+  SetOutPath "$PLUGINSDIR"
+  File /oname=check-install-space.ps1 "${PROJECT_DIR}\build\installer\check-install-space.ps1"
+  nsExec::ExecToStack 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\check-install-space.ps1" -EstimatedSizeKb "${ESTIMATED_SIZE}"'
   Pop $6
   Pop $7
-  ${If} $6 != 0
+  ${If} $6 == 1
     MessageBox MB_ICONEXCLAMATION "$(TTCUT_SPACE_REQUIRED)"
+    Abort
+  ${ElseIf} $6 != 0
+    MessageBox MB_ICONEXCLAMATION "$(TTCUT_SPACE_CHECK_FAILED)"
     Abort
   ${EndIf}
 

--- a/tests/nsis-installer.test.ts
+++ b/tests/nsis-installer.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { copyFile, mkdir, mkdtemp, readFile, rm, statfs, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,10 +7,21 @@ import { describe, expect, it } from 'vitest';
 const installerPath = path.join(process.cwd(), 'build', 'installer', 'installer.nsh');
 const makeNsisPath = path.join(process.cwd(), 'scripts', 'make-nsis.mjs');
 const compareVersionsPath = path.join(process.cwd(), 'build', 'installer', 'compare-versions.ps1');
+const chooseDefaultRootPath = path.join(process.cwd(), 'build', 'installer', 'choose-default-root.ps1');
+const checkInstallSpacePath = path.join(process.cwd(), 'build', 'installer', 'check-install-space.ps1');
+const commitRegistrationPath = path.join(process.cwd(), 'build', 'installer', 'commit-install-registration.ps1');
 const finalizeLegacyPath = path.join(process.cwd(), 'build', 'installer', 'finalize-legacy-install.ps1');
 const legacyRegistryKey = 'HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\TTcut';
 const legacyRollbackTestUnavailable = process.platform !== 'win32'
   || spawnSync('reg.exe', ['query', legacyRegistryKey]).status === 0;
+const powerShell2Probe = process.platform === 'win32'
+  ? spawnSync('powershell.exe', [
+    '-Version', '2', '-NoProfile', '-NonInteractive',
+    '-Command', '$PSVersionTable.PSVersion.Major',
+  ], { encoding: 'utf8' })
+  : null;
+const powerShell2Unavailable = powerShell2Probe?.status !== 0
+  || powerShell2Probe.stdout.trim() !== '2';
 
 describe('assisted NSIS installer contract', () => {
   it('forces a current-user three-step flow after install-mode initialization', async () => {
@@ -74,12 +85,110 @@ describe('assisted NSIS installer contract', () => {
     expect(source).not.toContain(
       '$$p=[IO.Path]::GetFullPath($$env:TTCUT_INSTALLER_ROOT)',
     );
-    expect(source).toContain('Sort-Object {[int64]$$_.FreeSpace} -Descending');
+    expect(source).toContain(
+      'File /oname=check-install-space.ps1 "${PROJECT_DIR}\\build\\installer\\check-install-space.ps1"',
+    );
     expect(source).toContain('EnableWindow $TTcutRootField 0');
     expect(source).toContain('EnableWindow $TTcutBrowseButton 0');
     expect(source).toContain('CreateShortcut "$SMPROGRAMS\\TTcut.lnk"');
     expect(source).toContain('CreateShortcut "$DESKTOP\\TTcut.lnk"');
     expect(source).toContain('WriteRegStr HKCU "Software\\TTcut\\Install" "PreservedDataRoot"');
+  });
+
+  it('keeps the first-run probes compatible with Windows 7 PowerShell', async () => {
+    const source = await readFile(installerPath, 'utf8');
+    const chooseDefaultRoot = await readFile(chooseDefaultRootPath, 'utf8');
+    const checkInstallSpace = await readFile(checkInstallSpacePath, 'utf8');
+    const commitRegistration = await readFile(commitRegistrationPath, 'utf8');
+    const compareVersions = await readFile(compareVersionsPath, 'utf8');
+
+    expect(source).toContain(
+      'File /oname=choose-default-root.ps1 "${PROJECT_DIR}\\build\\installer\\choose-default-root.ps1"',
+    );
+    expect(source).toContain(
+      'File /oname=check-install-space.ps1 "${PROJECT_DIR}\\build\\installer\\check-install-space.ps1"',
+    );
+    expect(source).not.toContain('Get-CimInstance');
+    expect(source).not.toContain('[IO.DriveInfo]::new');
+    expect(chooseDefaultRoot).toContain('Get-WmiObject');
+    expect(chooseDefaultRoot).not.toContain('Get-CimInstance');
+    expect(checkInstallSpace).toContain(
+      'New-Object -TypeName System.IO.DriveInfo -ArgumentList',
+    );
+    expect(checkInstallSpace).not.toContain('[Parameter(');
+    expect(checkInstallSpace).not.toContain('::new(');
+    expect(checkInstallSpace).not.toMatch(/Get-ChildItem[^\r\n]*-File/);
+    expect(commitRegistration).not.toContain('[ordered]');
+    expect(commitRegistration).not.toContain('[Parameter(');
+    expect(commitRegistration).not.toContain('ConvertTo-Json');
+    expect(commitRegistration).toContain('ConvertTo-TTcutJsonString');
+    expect(compareVersions).not.toContain('[Parameter(');
+    expect(compareVersions).not.toContain('[pscustomobject]');
+    expect(compareVersions).toContain('New-Object -TypeName PSObject -Property');
+  });
+
+  it.skipIf(powerShell2Unavailable)('writes a valid registration failure report in PowerShell 2', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'ttcut-registration-report-'));
+    const installRoot = path.join(root, 'install');
+    const reportPath = path.join(root, 'report.json');
+    try {
+      const result = spawnSync('powershell.exe', [
+        '-Version', '2', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+        '-File', commitRegistrationPath,
+        '-InstallRoot', installRoot,
+        '-AppGuid', 'invalid-guid',
+        '-Version', '1.1.0',
+        '-DesktopShortcut', '1',
+        '-ReportPath', reportPath,
+      ], { encoding: 'utf8' });
+
+      expect(result.status, result.stderr || result.stdout).toBe(11);
+      expect(JSON.parse(await readFile(reportPath, 'utf8'))).toMatchObject({
+        schema_version: 1,
+        status: 'failed',
+        install_root: installRoot,
+        app_guid: 'invalid-guid',
+        version: '1.1.0',
+        desktop_shortcut: 1,
+        error_code: 'INVALID_APP_GUID',
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(powerShell2Unavailable)('distinguishes enough space, low space, and probe failures in PowerShell 2', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'ttcut-space-probe-'));
+    try {
+      const filesystem = await statfs(root, { bigint: true });
+      const available = filesystem.bavail * filesystem.bsize;
+      const reserve = 512n * 1024n * 1024n;
+      const invoke = (installRoot: string, estimatedSizeKb: bigint) => spawnSync(
+        'powershell.exe',
+        [
+          '-Version', '2', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+          '-File', checkInstallSpacePath,
+          '-EstimatedSizeKb', estimatedSizeKb.toString(),
+        ],
+        {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            TTCUT_INSTALLER_ROOT: installRoot,
+            TTCUT_INSTALLER_LEGACY: '',
+            TTCUT_INSTALLER_LEGACY_APP: '',
+          },
+        },
+      ).status;
+
+      if (available > reserve + 1024n) {
+        expect(invoke(root, 1n)).toBe(0);
+      }
+      expect(invoke(root, (available / 1024n) + 1n)).toBe(1);
+      expect(invoke('', 1n)).toBe(2);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it('commits and activates the new install before transactionally removing the legacy app', async () => {
@@ -195,10 +304,15 @@ describe('assisted NSIS installer contract', () => {
     }
   }, 20_000);
 
-  it.skipIf(process.platform !== 'win32')('blocks semantic-version downgrades, including prerelease downgrades', () => {
+  it.skipIf(powerShell2Unavailable)('blocks semantic-version downgrades in PowerShell 2, including prerelease downgrades', () => {
     const compare = (installed: string, candidate: string) => spawnSync(
       'powershell.exe',
-      ['-NoProfile', '-NonInteractive', '-File', compareVersionsPath, '-InstalledVersion', installed, '-CandidateVersion', candidate],
+      [
+        '-Version', '2', '-NoProfile', '-NonInteractive',
+        '-File', compareVersionsPath,
+        '-InstalledVersion', installed,
+        '-CandidateVersion', candidate,
+      ],
       { encoding: 'utf8' },
     ).status;
 


### PR DESCRIPTION
## 变更
- 兼容 Windows 7 / PowerShell 2：用 `Get-WmiObject` 和 `New-Object` 替换不可用的 CIM/静态构造语法。
- 区分磁盘空间检查的“空间不足”和“探测失败”，避免把路径/权限错误误报为容量不足。
- 修正默认安装盘选择、旧进程关闭、版本比较、旧安装迁移登记及 NSIS 安装流程的 PowerShell 2 兼容性。
- 增加对应的 NSIS 合同测试和强制 PowerShell 2 回归覆盖。

## 影响
安装器在 Win7 上可更准确地选择安装位置、检查空间并报告错误；现代 Windows 行为保持不变。该 PR 不改变 Electron 运行时本身的系统版本支持范围。

## 验证
- `npm run typecheck`
- `npm test`（113 passed，8 skipped）
- `npx vitest run tests/nsis-installer.test.ts`（15 passed）
- 强制 PowerShell 2 脚本检查
- `npm run make`
- `node scripts/verify-release.mjs`

本地构建产物已验证为未签名，仅作安装器验证，不包含在提交中。