### PR TITLE
Fix GoPro multistream video decoding

### DIFF
--- a/src/main/analysis-environment.ts
+++ b/src/main/analysis-environment.ts
@@ -1,0 +1,12 @@
+export const OPENCV_FFMPEG_READ_ATTEMPTS = '65536';
+
+export function analysisProcessEnvironment(
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return {
+    ...environment,
+    // GoPro MP4 files can place tens of thousands of telemetry/timecode
+    // packets between video packets. OpenCV's default budget is only 4,096.
+    OPENCV_FFMPEG_READ_ATTEMPTS,
+  };
+}

--- a/src/main/analysis.ts
+++ b/src/main/analysis.ts
@@ -17,6 +17,7 @@ import { getHistoryStore } from './history';
 import { probeVideo } from './probe';
 import { hasActiveTasks, spawnTracked } from './processes';
 import { overallAnalysisProgress } from '../domain/analysis-progress';
+import { analysisProcessEnvironment } from './analysis-environment';
 
 function send(window: BrowserWindow, event: AppEvent): void {
   if (!window.isDestroyed()) window.webContents.send(IPC.taskEvent, event);
@@ -57,7 +58,7 @@ export async function startAnalysis(
   const child = spawnTracked(taskId, components.python, ['-m', 'ttcut_worker.worker'], {
     cwd: components.worker,
     env: {
-      ...process.env,
+      ...analysisProcessEnvironment(process.env),
       PYTHONPATH: components.worker,
       PYTHONUTF8: '1',
       TTCUT_TRACKNET_WEIGHTS: components.tracknetWeights,

--- a/src/main/calibration.ts
+++ b/src/main/calibration.ts
@@ -13,6 +13,7 @@ import { resolveUsableAnalysisComponents } from './components';
 import { logLine } from './logger';
 import { probeVideo } from './probe';
 import { hasActiveTasks, spawnTracked } from './processes';
+import { analysisProcessEnvironment } from './analysis-environment';
 
 function send(window: BrowserWindow, event: AppEvent): void {
   if (!window.isDestroyed()) window.webContents.send(IPC.taskEvent, event);
@@ -46,7 +47,7 @@ export async function startAutoCalibration(
   const child = spawnTracked(taskId, components.python, ['-m', 'ttcut_worker.calibration_worker'], {
     cwd: components.worker,
     env: {
-      ...process.env,
+      ...analysisProcessEnvironment(process.env),
       PYTHONPATH: components.worker,
       PYTHONUTF8: '1',
       TTCUT_TRACKNET_WEIGHTS: components.tracknetWeights,

--- a/tests/analysis-environment.test.ts
+++ b/tests/analysis-environment.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analysisProcessEnvironment,
+  OPENCV_FFMPEG_READ_ATTEMPTS,
+} from '../src/main/analysis-environment';
+
+describe('analysisProcessEnvironment', () => {
+  it('forces the OpenCV packet budget before the Python process starts', () => {
+    const environment = analysisProcessEnvironment({
+      KEEP_ME: 'yes',
+      OPENCV_FFMPEG_READ_ATTEMPTS: '4096',
+    });
+
+    expect(environment).toEqual({
+      KEEP_ME: 'yes',
+      OPENCV_FFMPEG_READ_ATTEMPTS: '65536',
+    });
+    expect(OPENCV_FFMPEG_READ_ATTEMPTS).toBe('65536');
+  });
+});

--- a/worker/tests/test_video.py
+++ b/worker/tests/test_video.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from ttcut_worker.errors import VideoError
+from ttcut_worker.video import _validate_decode_completion
+
+
+def test_materially_truncated_decode_is_not_reported_as_a_valid_short_video() -> None:
+    with pytest.raises(VideoError, match=r"21 of 18624 frames") as error:
+        _validate_decode_completion(21, 18_624)
+
+    assert error.value.code == "VIDEO_UNREADABLE"
+
+
+@pytest.mark.parametrize(
+    ("decoded_frame_count", "metadata_frame_count"),
+    [(90, 100), (100, 100), (3, None)],
+)
+def test_complete_or_unknown_length_decode_is_accepted(
+    decoded_frame_count: int,
+    metadata_frame_count: int | None,
+) -> None:
+    _validate_decode_completion(decoded_frame_count, metadata_frame_count)

--- a/worker/ttcut_worker/video.py
+++ b/worker/ttcut_worker/video.py
@@ -9,6 +9,8 @@ from .errors import VideoError
 from .timestamp import TimestampResolver, valid_fps
 from .types import TimeSource
 
+MINIMUM_DECODE_COMPLETION_RATIO = 0.9
+
 
 @dataclass(frozen=True)
 class VideoInfo:
@@ -49,6 +51,22 @@ def validate_video_path(value: str | Path) -> Path:
 
 def _count(value: float) -> int | None:
     return int(round(value)) if math.isfinite(value) and value > 0 else None
+
+
+def _validate_decode_completion(
+    decoded_frame_count: int,
+    metadata_frame_count: int | None,
+) -> None:
+    if decoded_frame_count <= 0:
+        raise VideoError("No frames were decoded.")
+    if (
+        metadata_frame_count is not None
+        and decoded_frame_count < metadata_frame_count * MINIMUM_DECODE_COMPLETION_RATIO
+    ):
+        raise VideoError(
+            "Video decoding stopped before the expected end "
+            f"({decoded_frame_count} of {metadata_frame_count} frames).",
+        )
 
 
 def probe_video(value: str | Path) -> VideoInfo:
@@ -101,8 +119,10 @@ class StreamingVideoReader:
                 index += 1
         finally:
             capture.release()
-        if not self.decoded_frame_count:
-            raise VideoError("No frames were decoded.")
+        _validate_decode_completion(
+            self.decoded_frame_count,
+            self.info.metadata_frame_count,
+        )
 
     def final_info(self) -> VideoInfo:
         return replace(


### PR DESCRIPTION
## Summary

- raise OpenCV's FFmpeg read-attempt budget for analysis and calibration workers
- detect severely truncated video decoding and return an explicit decode error
- add regression coverage for the worker environment and decode-completion guard

## Root cause

`GX010372.MP4` is a GoPro HEVC recording with additional audio, timecode, telemetry, and descriptor streams. OpenCV's default `OPENCV_FFMPEG_READ_ATTEMPTS=4096` budget was exhausted after only 21 of 18,624 video frames, so rally grouping received an effectively empty clip and reported that no rallies were recognized.

## Impact

The analysis and calibration workers now use a larger read-attempt budget, allowing this file to decode completely. If another file still ends far before its declared frame count, the worker reports a video-decode failure instead of the misleading no-rallies result.

## Validation

- `npm run typecheck`
- full Vitest suite: 35 files passed, 3 skipped; 136 tests passed, 8 skipped
- full Worker pytest suite: 53 passed
- `npm run package`
- packaged worker/source hash parity verified
- real CUDA analysis of `GX010372.MP4`: 18,624/18,624 frames decoded, 45 rallies and 219 bounce candidates with manual calibration