### PR TITLE
Preserve active video tasks and add batch completion shutdown

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -30,6 +30,7 @@ import {
 import { COMPONENT_ASSETS_RELEASE_URL, DONATION_URL, GITHUB_URL, RELEASES_URL, WEBSITE_URL } from '../shared/urls';
 import { getUpdater } from './updater';
 import { runInstallerMigrationRequest } from './installer-migration';
+import { requestSystemShutdown } from './system-power';
 
 const installerMigrationIndex = process.argv.indexOf('--installer-migrate-components');
 const installerMigrationRequest = installerMigrationIndex >= 0 ? process.argv[installerMigrationIndex + 1] : null;
@@ -291,6 +292,15 @@ function registerIpc(): void {
       exitApproved = true;
       await cancelAllTasksAndWait('app-exit');
       window.close();
+    }
+  });
+  ipcMain.handle(IPC.systemShutdown, async () => {
+    await logLine('app', 'INFO', 'System shutdown requested after a completed batch task.');
+    try {
+      await requestSystemShutdown({ isBusy: hasActiveTasks });
+    } catch (error) {
+      await logLine('app', 'ERROR', `System shutdown request failed: ${String(error)}`);
+      throw error;
     }
   });
 }

--- a/src/main/system-power.ts
+++ b/src/main/system-power.ts
@@ -1,0 +1,37 @@
+import { execFile } from 'node:child_process';
+
+type ShutdownDependencies = {
+  platform?: NodeJS.Platform;
+  isBusy?: () => boolean;
+  wait?: (milliseconds: number) => Promise<void>;
+  run?: (command: string, args: readonly string[]) => Promise<void>;
+};
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function runShutdown(command: string, args: readonly string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(command, [...args], { windowsHide: true }, (error) => {
+      if (error) reject(new Error('SYSTEM_SHUTDOWN_FAILED'));
+      else resolve();
+    });
+  });
+}
+
+export async function requestSystemShutdown({
+  platform = process.platform,
+  isBusy = () => false,
+  wait: waitFor = wait,
+  run = runShutdown,
+}: ShutdownDependencies = {}): Promise<void> {
+  if (platform !== 'win32') throw new Error('SYSTEM_SHUTDOWN_UNSUPPORTED');
+
+  for (let attempt = 0; attempt < 200 && isBusy(); attempt += 1) {
+    await waitFor(50);
+  }
+  if (isBusy()) throw new Error('TASK_BUSY');
+
+  await run('shutdown.exe', ['/s', '/t', '0']);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -52,6 +52,7 @@ const api: TTcutApi = {
   toggleMaximize: () => ipcRenderer.invoke(IPC.windowToggleMaximize),
   close: () => ipcRenderer.invoke(IPC.windowClose),
   confirmClose: (action: 'exit' | 'minimize' | 'cancel') => ipcRenderer.invoke(IPC.windowConfirmClose, action),
+  shutdownSystem: () => ipcRenderer.invoke(IPC.systemShutdown),
   onCloseRequested: (listener: () => void) => {
     const wrapped = () => listener();
     ipcRenderer.on(IPC.windowCloseRequested, wrapped);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,7 +8,7 @@ import { validateCalibration } from '../domain/calibration';
 import { isSupportedVideoFileName } from '../domain/video-input';
 import { isSupportPromptSuppressed, suppressSupportPromptForThirtyDays } from '../domain/support-prompt';
 import { interpolate, messages, type Language, type Messages } from './i18n';
-import { MultiTaskPage, type MultiLeaveTarget } from './MultiTaskPage';
+import { MultiTaskPage } from './MultiTaskPage';
 import { CalibrationSurface } from './CalibrationSurface';
 import { SupportPrompt } from './SupportPrompt';
 import packageJson from '../../package.json';
@@ -16,6 +16,7 @@ import captureGuideImage from './assets/pingpong-table-with-pose-mannequins.png'
 
 type View = 'auto' | 'history' | 'settings' | 'multi';
 type Step = 'select' | 'calibrate' | 'analyzing' | 'empty' | 'mode' | 'cutting' | 'complete' | 'error';
+type VideoTaskOwner = 'single' | 'multi' | null;
 type PointName = keyof Calibration['points'];
 
 const appVersion = packageJson.version;
@@ -137,6 +138,8 @@ export function App() {
   const [customIds, setCustomIds] = useState<Set<string>>(new Set());
   const [progress, setProgress] = useState({ percent: 0, stage: 'probe' });
   const [activeTask, setActiveTask] = useState<string | null>(null);
+  const [videoTaskOwner, setVideoTaskOwnerState] = useState<VideoTaskOwner>(null);
+  const videoTaskOwnerRef = useRef<VideoTaskOwner>(null);
   const [exportResult, setExportResult] = useState<ExportResult | null>(null);
   const [error, setError] = useState<{ code: string; recoveredOutputPath?: string } | null>(null);
   const [toast, setToast] = useState<string | null>(null);
@@ -148,7 +151,6 @@ export function App() {
   const setupTaskRef = useRef<string | null>(null);
   const pendingBallProfileRef = useRef<'uplifting_dual_v1' | null>(null);
   const multiActiveRef = useRef(false);
-  const multiLeaveHandlerRef = useRef<((target: MultiLeaveTarget) => void) | null>(null);
   const settingsRef = useRef(settings);
   const promptedUpdateVersion = useRef<string | null>(null);
   const [setupProgress, setSetupProgress] = useState<{ percent: number; stage: string; current?: number; total?: number } | null>(null);
@@ -161,6 +163,10 @@ export function App() {
   const [historyConfirmation, setHistoryConfirmation] = useState<{ kind: 'delete'; id: string } | { kind: 'clear' } | null>(null);
   const [missingComponents, setMissingComponents] = useState<string[] | null>(null);
   const [previewRally, setPreviewRally] = useState<Rally | null>(null);
+  const updateVideoTaskOwner = useCallback((owner: VideoTaskOwner) => {
+    videoTaskOwnerRef.current = owner;
+    setVideoTaskOwnerState(owner);
+  }, []);
   const t = messages(settings.language as Language);
   const platformSupported = bootstrap?.platformCompatibility.status === 'supported';
   const ballProfileReady = settings.ball_model_profile === 'tracknet_v1'
@@ -206,6 +212,7 @@ export function App() {
         setProgress({ percent: event.data.percent, stage: event.data.stage });
       } else if (event.type === 'analysis-result') {
         setActiveTask(null);
+        if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
         setAnalysisId(event.analysisId);
         setAnalysis(event.data);
         setPoints(event.calibration.points);
@@ -214,6 +221,7 @@ export function App() {
         return;
       } else if (event.type === 'export-result') {
         setActiveTask(null);
+        if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
         setExportResult(event.data);
         setStep('complete');
         showSupportPrompt();
@@ -248,6 +256,7 @@ export function App() {
         if (settingsRef.current.calibration_method === 'automatic'
           && ['AUTO_CALIBRATION_FAILED', 'TABLE_MODEL_RESOURCE_ERROR'].includes(event.code)) {
           setActiveTask(null);
+          if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
           setForceManual(true);
           setToast(event.code === 'TABLE_MODEL_RESOURCE_ERROR'
             ? (settingsRef.current.language === 'zh-CN' ? '自动标定模型不可用，请改用手动标定。' : 'The automatic calibration model is unavailable. Please calibrate manually.')
@@ -257,10 +266,12 @@ export function App() {
         }
         if (event.code === 'EXPORT_CANCELLED') {
           setActiveTask(null);
+          if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
           setStep('mode');
           return;
         }
         setActiveTask(null);
+        if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
         setError({
           code: event.code,
           ...(event.recoveredOutputPath ? { recoveredOutputPath: event.recoveredOutputPath } : {}),
@@ -272,7 +283,7 @@ export function App() {
     const removeUpdate = window.ttcut.onUpdateState(setUpdateState);
     void window.ttcut.getUpdateState().then(setUpdateState);
     return () => { removeTask(); removeClose(); removeUpdate(); };
-  }, [showSupportPrompt]);
+  }, [showSupportPrompt, updateVideoTaskOwner]);
 
   useEffect(() => { settingsRef.current = settings; }, [settings]);
   useEffect(() => {
@@ -293,7 +304,8 @@ export function App() {
     setStep('select'); setVideo(null); setMetadata(null); setPoints({}); setAnalysis(null); setAnalysisId(null); setForceManual(false);
     setMode('all'); setThreshold(5); setCustomIds(new Set()); setProgress({ percent: 0, stage: 'probe' });
     setActiveTask(null); setExportResult(null); setError(null);
-  }, []);
+    if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
+  }, [updateVideoTaskOwner]);
 
   const acceptVideo = async (selected: SelectedVideo | null) => {
     if (!selected) return;
@@ -312,6 +324,7 @@ export function App() {
       return;
     }
     multiActiveRef.current = true;
+    updateVideoTaskOwner('multi');
     setMultiVideos(selected);
     setView('multi');
   };
@@ -328,6 +341,7 @@ export function App() {
 
   const startAnalysis = async () => {
     if (!video || !metadata || (useManualCalibration && (!calibrationValue || calibrationIssue)) || !platformSupported || !bootstrap?.components.analysis.available || !ballProfileReady) return;
+    updateVideoTaskOwner('single');
     setStep('analyzing'); setProgress({ percent: 0, stage: 'load_model' });
     try {
       setActiveTask(await window.ttcut.startAnalysis({
@@ -338,6 +352,7 @@ export function App() {
         ballModelProfile: settings.ball_model_profile,
       }));
     } catch (caught) {
+      if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
       setError({ code: errorCode(caught) }); setStep('error');
     }
   };
@@ -349,6 +364,7 @@ export function App() {
     if (mode === 'all') selection = { mode, ...common };
     else if (mode === 'highlight') selection = { mode, highlight_threshold: threshold, ...common };
     else selection = { mode, selected_rally_ids: [...customIds], ...common };
+    updateVideoTaskOwner('single');
     setStep('cutting'); setProgress({ percent: 0, stage: 'preparing' });
     try {
       setActiveTask(await window.ttcut.startExport({
@@ -357,6 +373,7 @@ export function App() {
         destination: 'source',
       }));
     } catch (caught) {
+      if (videoTaskOwnerRef.current === 'single') updateVideoTaskOwner(null);
       setError({ code: errorCode(caught) }); setStep('error');
     }
   };
@@ -398,6 +415,7 @@ export function App() {
   };
 
   const openHistory = async (id: string) => {
+    if (videoTaskOwnerRef.current) return;
     try {
       const opened = await window.ttcut.openHistory(id);
       setVideo(opened.video);
@@ -421,7 +439,7 @@ export function App() {
 
   const confirmHistoryAction = async () => {
     const confirmation = historyConfirmation;
-    if (!confirmation) return;
+    if (!confirmation || videoTaskOwnerRef.current) return;
     setHistoryConfirmation(null);
     setHistoryError(null);
     try {
@@ -447,6 +465,7 @@ export function App() {
   };
 
   const importComponents = async () => {
+    if (videoTaskOwnerRef.current) return;
     setSetupOutcome(null);
     setSetupFailureCode(null);
     setSetupPendingImports([]);
@@ -467,6 +486,7 @@ export function App() {
   };
 
   const installMediaComponent = async () => {
+    if (videoTaskOwnerRef.current) return;
     setSetupOutcome(null);
     setSetupFailureCode(null);
     if (!platformSupported) {
@@ -485,6 +505,7 @@ export function App() {
   };
 
   const installAnalysisComponent = async () => {
+    if (videoTaskOwnerRef.current) return;
     setSetupOutcome(null);
     setSetupFailureCode(null);
     if (!platformSupported) {
@@ -503,6 +524,7 @@ export function App() {
   };
 
   const installDualBallModels = async (selectAfterInstall = false) => {
+    if (videoTaskOwnerRef.current) return;
     setSetupOutcome(null);
     setSetupFailureCode(null);
     if (!platformSupported || bootstrap?.components.analysis.acceleration !== 'cuda') {
@@ -546,7 +568,7 @@ export function App() {
     received: pending.receivedParts,
     total: pending.totalParts,
   })).join(' ');
-  const canReturnToSelection = view === 'multi' || (
+  const canReturnToSelection = (view === 'multi' && videoTaskOwner !== 'multi') || (
     view === 'auto'
       && step !== 'select'
       && step !== 'analyzing'
@@ -555,26 +577,16 @@ export function App() {
       && !activeTask
       && !setupTask
   );
-  const leaveMulti = (target: MultiLeaveTarget) => {
+  const discardMulti = () => {
     multiActiveRef.current = false;
     setMultiVideos([]);
-    if (target === 'history') {
-      showHistory();
-      return;
-    }
-    if (target === 'settings') {
-      reset();
-      setView('settings');
-      return;
-    }
-    reset();
-    setView('auto');
+    if (videoTaskOwnerRef.current === 'multi') updateVideoTaskOwner(null);
   };
-  const requestView = (target: MultiLeaveTarget) => {
-    if (view === 'multi') {
-      multiLeaveHandlerRef.current?.(target);
-      return;
-    }
+  const handleMultiTaskStateChange = (active: boolean) => {
+    if (active && videoTaskOwnerRef.current !== 'multi') updateVideoTaskOwner('multi');
+    if (!active && videoTaskOwnerRef.current === 'multi') updateVideoTaskOwner(null);
+  };
+  const requestView = (target: Exclude<View, 'multi'>) => {
     if (target === 'history') {
       showHistory();
       return;
@@ -583,6 +595,15 @@ export function App() {
       setView('settings');
       return;
     }
+    if (videoTaskOwnerRef.current === 'single') {
+      setView('auto');
+      return;
+    }
+    if (videoTaskOwnerRef.current === 'multi') {
+      setView('multi');
+      return;
+    }
+    if (multiVideos.length > 0) discardMulti();
     reset();
     setView('auto');
   };
@@ -618,19 +639,21 @@ export function App() {
       </aside>
 
       <main className="main-content">
-        {view === 'multi' ? (
-          <MultiTaskPage
-            initialVideos={multiVideos}
-            preRoll={settings.pre_roll_seconds}
-            postRoll={settings.post_roll_seconds}
-            ballModelProfile={settings.ball_model_profile}
-            language={settings.language}
-            registerLeaveHandler={(handler) => { multiLeaveHandlerRef.current = handler; }}
-            onLeave={leaveMulti}
-            onOpenAnalysis={(id) => { multiActiveRef.current = false; void openHistory(id); }}
-            onCompletableTasksFinished={showSupportPrompt}
-          />
-        ) : view === 'settings' ? (
+        {multiVideos.length > 0 && (
+          <div hidden={view !== 'multi'}>
+            <MultiTaskPage
+              initialVideos={multiVideos}
+              preRoll={settings.pre_roll_seconds}
+              postRoll={settings.post_roll_seconds}
+              ballModelProfile={settings.ball_model_profile}
+              language={settings.language}
+              onTaskStateChange={handleMultiTaskStateChange}
+              onOpenAnalysis={(id) => { discardMulti(); void openHistory(id); }}
+              onCompletableTasksFinished={showSupportPrompt}
+            />
+          </div>
+        )}
+        {view !== 'multi' && (view === 'settings' ? (
           <section className="page settings-page">
             <div className="page-heading settings-heading"><h1>{t.settings}</h1></div>
             <div className="settings-grid">
@@ -661,7 +684,7 @@ export function App() {
                 <div><h2>{settings.language === 'zh-CN' ? '球识别模型' : 'Ball recognition model'}</h2></div>
                 <div className="model-profile-options">
                   <button className={settings.ball_model_profile === 'tracknet_v1' ? 'selected' : ''} onClick={() => void selectBallModelProfile('tracknet_v1')}><strong>{settings.language === 'zh-CN' ? '默认模型' : 'Default model'}</strong><span>{settings.language === 'zh-CN' ? '速度快，精准度一般。' : 'Fast, with average accuracy.'}</span></button>
-                  <button disabled={bootstrap?.components.analysis.acceleration !== 'cuda' || Boolean(setupTask)} className={settings.ball_model_profile === 'uplifting_dual_v1' ? 'selected' : ''} onClick={() => void selectBallModelProfile('uplifting_dual_v1')}><strong>{settings.language === 'zh-CN' ? '新模型' : 'New model'}</strong><span>{settings.language === 'zh-CN' ? '速度慢，准确度很高。' : 'Slower, with very high accuracy.'}</span></button>
+                  <button disabled={bootstrap?.components.analysis.acceleration !== 'cuda' || Boolean(setupTask) || Boolean(videoTaskOwner && !bootstrap?.components.dual_ball_models.available)} className={settings.ball_model_profile === 'uplifting_dual_v1' ? 'selected' : ''} onClick={() => void selectBallModelProfile('uplifting_dual_v1')}><strong>{settings.language === 'zh-CN' ? '新模型' : 'New model'}</strong><span>{settings.language === 'zh-CN' ? '速度慢，准确度很高。' : 'Slower, with very high accuracy.'}</span></button>
                 </div>
               </article>
               <article className="card setting-card">
@@ -698,20 +721,20 @@ export function App() {
                 ) : (
                   <div className="setup-options">
                     {bootstrap?.componentSetup.analysis_offer && !bootstrap.components.analysis.available && (
-                      <div className="setup-option"><div><strong>{t.analysisOffer}</strong><span>{t.analysisOfferDetail}</span><small>{interpolate(t.downloadUpTo, { size: fileSize(bootstrap.componentSetup.analysis_offer.download_size_bytes) })}</small><small className="setup-network-hint">{t.networkHint}</small></div><div><button className="text-button" onClick={() => void window.ttcut.openExternalUrl(bootstrap.componentSetup.analysis_offer!.license_url)}>{t.viewLicense}</button><button className="primary" disabled={!platformSupported || !bootstrap.componentSetup.analysis_offer.available_for_download} onClick={() => void installAnalysisComponent()}>{t.consentInstall}</button></div></div>
+                      <div className="setup-option"><div><strong>{t.analysisOffer}</strong><span>{t.analysisOfferDetail}</span><small>{interpolate(t.downloadUpTo, { size: fileSize(bootstrap.componentSetup.analysis_offer.download_size_bytes) })}</small><small className="setup-network-hint">{t.networkHint}</small></div><div><button className="text-button" onClick={() => void window.ttcut.openExternalUrl(bootstrap.componentSetup.analysis_offer!.license_url)}>{t.viewLicense}</button><button className="primary" disabled={!platformSupported || !bootstrap.componentSetup.analysis_offer.available_for_download || Boolean(videoTaskOwner)} onClick={() => void installAnalysisComponent()}>{t.consentInstall}</button></div></div>
                     )}
                     {bootstrap?.componentSetup.media_offer && !bootstrap.components.media.available && (
-                      <div className="setup-option"><div><strong>{t.mediaOffer}</strong><span>{t.mediaOfferDetail}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.media_offer.download_size_bytes) })}</small></div><div><button className="text-button" onClick={() => void window.ttcut.openExternalUrl(bootstrap.componentSetup.media_offer!.license_url)}>{t.viewLicense}</button><button className="primary" disabled={!platformSupported || !bootstrap.componentSetup.media_offer.available_for_download} onClick={() => void installMediaComponent()}>{t.consentInstall}</button></div></div>
+                      <div className="setup-option"><div><strong>{t.mediaOffer}</strong><span>{t.mediaOfferDetail}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.media_offer.download_size_bytes) })}</small></div><div><button className="text-button" onClick={() => void window.ttcut.openExternalUrl(bootstrap.componentSetup.media_offer!.license_url)}>{t.viewLicense}</button><button className="primary" disabled={!platformSupported || !bootstrap.componentSetup.media_offer.available_for_download || Boolean(videoTaskOwner)} onClick={() => void installMediaComponent()}>{t.consentInstall}</button></div></div>
                     )}
                     {bootstrap?.componentSetup.dual_ball_models_offer && !bootstrap.components.dual_ball_models.available && (
-                      <div className="setup-option optional-component"><div><strong>{settings.language === 'zh-CN' ? '安装 Uplifting 双球模型' : 'Install Uplifting dual ball models'}</strong><span>{settings.language === 'zh-CN' ? '两个固定权重，下载后逐文件校验并原子安装；仅 CUDA 可用。' : 'Two pinned weights, verified per file and installed atomically; CUDA only.'}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.dual_ball_models_offer.download_size_bytes) })}</small></div><div><button className="primary" disabled={bootstrap.components.analysis.acceleration !== 'cuda' || Boolean(setupTask)} onClick={() => void installDualBallModels(false)}>{t.consentInstall}</button></div></div>
+                      <div className="setup-option optional-component"><div><strong>{settings.language === 'zh-CN' ? '安装 Uplifting 双球模型' : 'Install Uplifting dual ball models'}</strong><span>{settings.language === 'zh-CN' ? '两个固定权重，下载后逐文件校验并原子安装；仅 CUDA 可用。' : 'Two pinned weights, verified per file and installed atomically; CUDA only.'}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.dual_ball_models_offer.download_size_bytes) })}</small></div><div><button className="primary" disabled={bootstrap.components.analysis.acceleration !== 'cuda' || Boolean(setupTask) || Boolean(videoTaskOwner)} onClick={() => void installDualBallModels(false)}>{t.consentInstall}</button></div></div>
                     )}
                     {bootstrap?.componentSetup.x264_manual_offer && !bootstrap.components.media.x264_available && (
                       <div className="setup-option optional-component"><div><strong>{t.x264ManualOffer}</strong><span>{t.x264ManualDetail}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.x264_manual_offer.download_size_bytes) })}</small></div><div><button className="secondary" disabled={Boolean(setupTask)} onClick={() => void window.ttcut.openX264Download()}>{t.goToDownload}</button></div></div>
                     )}
                     <div className="setup-manual">
                       <div><strong>{t.manualDownload}</strong></div>
-                      <div className="setup-manual-actions"><button className="text-button" disabled={Boolean(setupTask)} onClick={() => void window.ttcut.openComponentDownloads()}>{t.goToDownload}</button><button className="secondary" disabled={!platformSupported || Boolean(setupTask)} onClick={() => void importComponents()}>{t.importComponents}</button></div>
+                      <div className="setup-manual-actions"><button className="text-button" disabled={Boolean(setupTask)} onClick={() => void window.ttcut.openComponentDownloads()}>{t.goToDownload}</button><button className="secondary" disabled={!platformSupported || Boolean(setupTask) || Boolean(videoTaskOwner)} onClick={() => void importComponents()}>{t.importComponents}</button></div>
                     </div>
                   </div>
                 )}
@@ -726,22 +749,22 @@ export function App() {
           </section>
         ) : view === 'history' ? (
           <section className="page history-page">
-            <div className="history-header"><div className="page-heading"><h1>{t.history}</h1><p>{t.historyDescription}</p></div><button className="secondary" disabled={historyEntries.length === 0 || Boolean(activeTask || setupTask)} onClick={() => setHistoryConfirmation({ kind: 'clear' })}>{t.clearHistory}</button></div>
+            <div className="history-header"><div className="page-heading"><h1>{t.history}</h1><p>{t.historyDescription}</p></div><button className="secondary" disabled={historyEntries.length === 0 || Boolean(activeTask || setupTask || videoTaskOwner)} onClick={() => setHistoryConfirmation({ kind: 'clear' })}>{t.clearHistory}</button></div>
             {historyError && <div className="history-error" role="alert"><span>{localizedError(historyError, t)}</span><button className="text-button" onClick={() => void loadHistory()}>{t.retry}</button></div>}
             {historyLoading ? (
               <div className="history-loading" role="status">{t.loadingHistory}</div>
             ) : historyEntries.length === 0 ? (
-              <div className="empty-state history-empty"><span>○</span><h1>{t.noHistory}</h1><p>{t.noHistoryDetail}</p><button className="primary" onClick={() => { reset(); setView('auto'); }}>{t.startFirstAnalysis}</button></div>
+              <div className="empty-state history-empty"><span>○</span><h1>{t.noHistory}</h1><p>{t.noHistoryDetail}</p><button className="primary" onClick={() => requestView('auto')}>{t.startFirstAnalysis}</button></div>
             ) : (
               <div className="history-grid">
                 {historyEntries.map((entry) => {
                   const unavailable = entry.source_status !== 'available';
                   return <article className={`history-card card ${unavailable ? 'unavailable' : ''}`} key={entry.id}>
-                    <button className="history-open" disabled={unavailable || Boolean(activeTask || setupTask)} onClick={() => void openHistory(entry.id)}>
+                    <button className="history-open" disabled={unavailable || Boolean(activeTask || setupTask || videoTaskOwner)} onClick={() => void openHistory(entry.id)}>
                       <div className="history-cover">{entry.cover_url ? <img src={entry.cover_url} alt="" /> : <span>{t.coverUnavailable}</span>}</div>
                       <div className="history-info"><strong title={entry.video_name}>{entry.video_name}</strong><div><span>{interpolate(t.historyRallies, { count: entry.rally_count })}</span><span>{formatTimestamp(entry.duration_seconds)}</span></div>{unavailable && <small>{entry.source_status === 'missing' ? t.historyMissing : t.historyChanged}</small>}</div>
                     </button>
-                    <button className="history-delete" disabled={Boolean(activeTask || setupTask)} aria-label={interpolate(t.deleteHistoryItem, { name: entry.video_name })} onClick={() => setHistoryConfirmation({ kind: 'delete', id: entry.id })}>×</button>
+                    <button className="history-delete" disabled={Boolean(activeTask || setupTask || videoTaskOwner)} aria-label={interpolate(t.deleteHistoryItem, { name: entry.video_name })} onClick={() => setHistoryConfirmation({ kind: 'delete', id: entry.id })}>×</button>
                   </article>;
                 })}
               </div>
@@ -853,7 +876,7 @@ export function App() {
               </div>
             )}
           </section>
-        )}
+        ))}
       </main>
 
       {view === 'auto' && step === 'select' && (

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -458,7 +458,7 @@ export function App() {
       ...(!components.analysis.available ? [t.analysisComponent] : []),
       ...(!components.media.available ? [t.mediaComponent] : []),
       ...(settings.ball_model_profile === 'uplifting_dual_v1' && (!components.dual_ball_models.available || components.analysis.acceleration !== 'cuda')
-        ? [settings.language === 'zh-CN' ? 'Uplifting 双球模型（CUDA）' : 'Uplifting dual ball models (CUDA)']
+        ? [settings.language === 'zh-CN' ? '高精度双检测模型（CUDA）' : 'High-accuracy dual detection models (CUDA)']
         : []),
     ];
     setMissingComponents(missing.length > 0 ? missing : null);
@@ -528,7 +528,7 @@ export function App() {
     setSetupOutcome(null);
     setSetupFailureCode(null);
     if (!platformSupported || bootstrap?.components.analysis.acceleration !== 'cuda') {
-      setToast(settings.language === 'zh-CN' ? 'Uplifting 双模型仅支持 CUDA。' : 'Uplifting dual models require CUDA.');
+      setToast(settings.language === 'zh-CN' ? '高精度双检测模型仅支持 CUDA。' : 'High-accuracy dual detection models require CUDA.');
       return;
     }
     if (selectAfterInstall) pendingBallProfileRef.current = 'uplifting_dual_v1';
@@ -706,7 +706,7 @@ export function App() {
                 <h2>{t.components}</h2>
                 <div className="component-row"><div><strong>{t.analysisComponent}</strong><span>{bootstrap?.components.analysis.version ?? t.unavailable}</span>{bootstrap?.components.analysis.path && <span>{t.componentPath}: {bootstrap.components.analysis.path}</span>}</div><span className={`status ${bootstrap?.components.analysis.available ? 'ok' : ''}`}>{bootstrap?.components.analysis.available ? t.available : t.unavailable}</span></div>
                 <div className="component-row"><div><strong>{t.mediaComponent}</strong><span>{bootstrap?.components.media.version ?? t.unavailable}</span>{bootstrap?.components.media.available && <span>{t.activeEncoder}: {bootstrap.components.media.active_encoder === 'libx264' ? t.x264 : t.openh264}</span>}{bootstrap?.components.media.path && <span>{t.componentPath}: {bootstrap.components.media.path}</span>}</div><span className={`status ${bootstrap?.components.media.available ? 'ok' : ''}`}>{bootstrap?.components.media.available ? t.available : t.unavailable}</span></div>
-                <div className="component-row"><div><strong>{settings.language === 'zh-CN' ? 'Uplifting 双球模型' : 'Uplifting dual ball models'}</strong><span>{bootstrap?.components.dual_ball_models.version ?? bootstrap?.components.dual_ball_models.detail ?? t.unavailable}</span></div><span className={`status ${bootstrap?.components.dual_ball_models.available ? 'ok' : ''}`}>{bootstrap?.components.dual_ball_models.available ? t.available : t.unavailable}</span></div>
+                <div className="component-row"><div><strong>{settings.language === 'zh-CN' ? '高精度双检测模型' : 'High-accuracy dual detection models'}</strong><span>{bootstrap?.components.dual_ball_models.version ?? bootstrap?.components.dual_ball_models.detail ?? t.unavailable}</span>{bootstrap?.components.dual_ball_models.path && <span>{t.componentPath}: {bootstrap.components.dual_ball_models.path}</span>}</div><span className={`status ${bootstrap?.components.dual_ball_models.available ? 'ok' : ''}`}>{bootstrap?.components.dual_ball_models.available ? t.available : t.unavailable}</span></div>
                 <div className="component-row"><div><strong>{t.acceleration}</strong><span>{bootstrap?.components.analysis.acceleration === 'cuda' ? t.gpu : bootstrap?.components.analysis.acceleration === 'cpu' ? t.cpu : t.unavailable}</span></div></div>
               </article>
               <article className="card setup-card">
@@ -727,7 +727,7 @@ export function App() {
                       <div className="setup-option"><div><strong>{t.mediaOffer}</strong><span>{t.mediaOfferDetail}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.media_offer.download_size_bytes) })}</small></div><div><button className="text-button" onClick={() => void window.ttcut.openExternalUrl(bootstrap.componentSetup.media_offer!.license_url)}>{t.viewLicense}</button><button className="primary" disabled={!platformSupported || !bootstrap.componentSetup.media_offer.available_for_download || Boolean(videoTaskOwner)} onClick={() => void installMediaComponent()}>{t.consentInstall}</button></div></div>
                     )}
                     {bootstrap?.componentSetup.dual_ball_models_offer && !bootstrap.components.dual_ball_models.available && (
-                      <div className="setup-option optional-component"><div><strong>{settings.language === 'zh-CN' ? '安装 Uplifting 双球模型' : 'Install Uplifting dual ball models'}</strong><span>{settings.language === 'zh-CN' ? '两个固定权重，下载后逐文件校验并原子安装；仅 CUDA 可用。' : 'Two pinned weights, verified per file and installed atomically; CUDA only.'}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.dual_ball_models_offer.download_size_bytes) })}</small></div><div><button className="primary" disabled={bootstrap.components.analysis.acceleration !== 'cuda' || Boolean(setupTask) || Boolean(videoTaskOwner)} onClick={() => void installDualBallModels(false)}>{t.consentInstall}</button></div></div>
+                      <div className="setup-option optional-component"><div><strong>{settings.language === 'zh-CN' ? '安装高精度双检测模型' : 'Install high-accuracy dual detection models'}</strong><span>{settings.language === 'zh-CN' ? '两个固定权重，下载后逐文件校验并原子安装；仅 CUDA 可用。' : 'Two pinned weights, verified per file and installed atomically; CUDA only.'}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.dual_ball_models_offer.download_size_bytes) })}</small></div><div><button className="primary" disabled={bootstrap.components.analysis.acceleration !== 'cuda' || Boolean(setupTask) || Boolean(videoTaskOwner)} onClick={() => void installDualBallModels(false)}>{t.consentInstall}</button></div></div>
                     )}
                     {bootstrap?.componentSetup.x264_manual_offer && !bootstrap.components.media.x264_available && (
                       <div className="setup-option optional-component"><div><strong>{t.x264ManualOffer}</strong><span>{t.x264ManualDetail}</span><small>{interpolate(t.downloadSize, { size: fileSize(bootstrap.componentSetup.x264_manual_offer.download_size_bytes) })}</small></div><div><button className="secondary" disabled={Boolean(setupTask)} onClick={() => void window.ttcut.openX264Download()}>{t.goToDownload}</button></div></div>

--- a/src/renderer/MultiTaskPage.tsx
+++ b/src/renderer/MultiTaskPage.tsx
@@ -20,8 +20,6 @@ type ProcessingStatus = 'waiting' | 'analyzing' | 'exporting' | 'cancelled' | 'f
 type ActivePhase = 'calibration' | 'analysis' | 'export';
 type PointName = keyof Calibration['points'];
 
-export type MultiLeaveTarget = 'auto' | 'history' | 'settings';
-
 type BatchItem = {
   id: string;
   video: SelectedVideo;
@@ -49,8 +47,7 @@ interface MultiTaskPageProps {
   language?: 'zh-CN' | 'en';
   onOpenAnalysis: (analysisId: string) => void;
   onCompletableTasksFinished?: () => void;
-  registerLeaveHandler?: (handler: ((target: MultiLeaveTarget) => void) | null) => void;
-  onLeave?: (target: MultiLeaveTarget) => void;
+  onTaskStateChange?: (active: boolean) => void;
 }
 
 const pointOrder: PointName[] = ['top_left', 'top_right', 'bottom_right', 'bottom_left'];
@@ -90,6 +87,15 @@ function hasPendingCalibration(items: BatchItem[]): boolean {
   return items.some((item) => item.calibrationStatus === 'pending' || item.calibrationStatus === 'calibrating');
 }
 
+function hasOpenBatchWork(items: BatchItem[]): boolean {
+  return items.some((item) => (
+    item.calibrationStatus === 'pending'
+    || item.calibrationStatus === 'calibrating'
+    || (item.calibrationStatus === 'ready'
+      && ['waiting', 'analyzing', 'exporting'].includes(item.processingStatus))
+  ));
+}
+
 export function MultiTaskPage({
   initialVideos,
   preRoll,
@@ -98,10 +104,10 @@ export function MultiTaskPage({
   language = 'zh-CN',
   onOpenAnalysis,
   onCompletableTasksFinished = () => undefined,
-  registerLeaveHandler = () => undefined,
-  onLeave = () => undefined,
+  onTaskStateChange = () => undefined,
 }: MultiTaskPageProps) {
   const [items, setItems] = useState<BatchItem[]>([]);
+  const [initialized, setInitialized] = useState(false);
   const [activeItem, setActiveItem] = useState<string | null>(null);
   const [activePhase, setActivePhase] = useState<ActivePhase | null>(null);
   const [running, setRunning] = useState(false);
@@ -113,14 +119,13 @@ export function MultiTaskPage({
   const activeRef = useRef<{ taskId: string | null; itemId: string; phase: ActivePhase } | null>(null);
   const runningRef = useRef(false);
   const cancelRequested = useRef(false);
-  const leavingRef = useRef(false);
   const autoCalibrationAvailableRef = useRef(true);
   const pendingTaskStartRef = useRef<Promise<string> | null>(null);
   const scheduleRef = useRef<() => void>(() => undefined);
   const rowRefs = useRef(new Map<string, HTMLElement>());
   const previousRects = useRef(new Map<string, DOMRect>());
-  const optionsRef = useRef({ preRoll, postRoll });
-  optionsRef.current = { preRoll, postRoll };
+  const optionsRef = useRef({ preRoll, postRoll, ballModelProfile });
+  optionsRef.current = { preRoll, postRoll, ballModelProfile };
 
   const isEnglish = language === 'en';
   const text = {
@@ -147,9 +152,6 @@ export function MultiTaskPage({
     modelUnavailable: isEnglish
       ? 'The automatic calibration model is unavailable. Uncalibrated videos can be calibrated manually.'
       : '自动标定模型不可用，尚未标定的视频可改用手动标定。',
-    leaveConfirm: isEnglish
-      ? 'A batch task is still running. Cancel it and leave this page?'
-      : '多任务仍在运行，确定取消当前任务并离开吗？',
     invalidCalibration: isEnglish
       ? 'The four points must form a valid table quadrilateral.'
       : '四个点无法组成有效的球台区域，请重新标定。',
@@ -160,6 +162,8 @@ export function MultiTaskPage({
 
   useEffect(() => { itemsRef.current = items; }, [items]);
   useEffect(() => { runningRef.current = running; }, [running]);
+  const batchTaskActive = !initialized || running || hasOpenBatchWork(items);
+  useEffect(() => onTaskStateChange(batchTaskActive), [batchTaskActive, onTaskStateChange]);
 
   const replaceItems = (updater: (current: BatchItem[]) => BatchItem[]) => {
     const next = updater(itemsRef.current);
@@ -178,7 +182,7 @@ export function MultiTaskPage({
   };
 
   const schedule = () => {
-    if (leavingRef.current || activeRef.current) return;
+    if (activeRef.current) return;
     const calibrationCandidate = itemsRef.current.find((item) => item.calibrationStatus === 'pending');
     if (calibrationCandidate) {
       if (!autoCalibrationAvailableRef.current) {
@@ -199,14 +203,7 @@ export function MultiTaskPage({
       pendingTaskStartRef.current = startPromise;
       void startPromise
         .then((taskId) => {
-          if (activeRef.current?.itemId !== itemId || activeRef.current.phase !== 'calibration') {
-            if (leavingRef.current) void window.ttcut.cancelTask(taskId);
-            return;
-          }
-          if (leavingRef.current) {
-            void window.ttcut.cancelTask(taskId);
-            return;
-          }
+          if (activeRef.current?.itemId !== itemId || activeRef.current.phase !== 'calibration') return;
           activeRef.current = { taskId, itemId, phase: 'calibration' };
         })
         .catch((caught) => {
@@ -223,7 +220,7 @@ export function MultiTaskPage({
     if (!runningRef.current) return;
     const candidate = itemsRef.current.find((item) => (
       item.calibrationStatus === 'ready'
-      && ['waiting', 'cancelled'].includes(item.processingStatus)
+      && item.processingStatus === 'waiting'
     ));
     if (!candidate) {
       runningRef.current = false;
@@ -248,14 +245,7 @@ export function MultiTaskPage({
       });
       pendingTaskStartRef.current = startPromise;
       void startPromise.then((taskId) => {
-        if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'export') {
-          if (leavingRef.current) void window.ttcut.cancelTask(taskId);
-          return;
-        }
-        if (leavingRef.current) {
-          void window.ttcut.cancelTask(taskId);
-          return;
-        }
+        if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'export') return;
         activeRef.current = { taskId, itemId: candidate.id, phase: 'export' };
       }).catch((caught) => {
         if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'export') return;
@@ -296,18 +286,11 @@ export function MultiTaskPage({
       calibrationChoice,
       device: 'auto',
       historyVisibility: candidate.mode === 'analyze-only' ? 'visible' : 'deferred',
-      ballModelProfile,
+      ballModelProfile: optionsRef.current.ballModelProfile,
     });
     pendingTaskStartRef.current = startPromise;
     void startPromise.then((taskId) => {
-      if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'analysis') {
-        if (leavingRef.current) void window.ttcut.cancelTask(taskId);
-        return;
-      }
-      if (leavingRef.current) {
-        void window.ttcut.cancelTask(taskId);
-        return;
-      }
+      if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'analysis') return;
       activeRef.current = { taskId, itemId: candidate.id, phase: 'analysis' };
     }).catch((caught) => {
       if (activeRef.current?.itemId !== candidate.id || activeRef.current.phase !== 'analysis') return;
@@ -327,7 +310,10 @@ export function MultiTaskPage({
       if (cancelled) return;
       itemsRef.current = created;
       setItems(created);
+      setInitialized(true);
       setTimeout(() => scheduleRef.current(), 0);
+    }).catch(() => {
+      if (!cancelled) setInitialized(true);
     });
     return () => { cancelled = true; };
   }, [initialVideos]);
@@ -455,7 +441,6 @@ export function MultiTaskPage({
     const unique = videos.filter((video) => !existing.has(video.path.toLowerCase()));
     if (!unique.length) return;
     const created = await createItems(unique);
-    if (leavingRef.current) return;
     const added = autoCalibrationAvailableRef.current
       ? created
       : created.map((item) => ({ ...item, calibrationStatus: 'manual-required' as const }));
@@ -520,31 +505,6 @@ export function MultiTaskPage({
     setManualPoints({});
     setTimeout(() => scheduleRef.current(), 0);
   };
-
-  const leave = async (target: MultiLeaveTarget) => {
-    if (leavingRef.current) return;
-    leavingRef.current = true;
-    runningRef.current = false;
-    setRunning(false);
-    const active = activeRef.current;
-    const pendingStart = pendingTaskStartRef.current;
-    finishActive();
-    let taskId = active?.taskId ?? null;
-    if (!taskId && pendingStart) {
-      taskId = await pendingStart.catch(() => null);
-    }
-    if (taskId) await window.ttcut.cancelTask(taskId);
-    onLeave(target);
-  };
-
-  useEffect(() => {
-    const handler = (target: MultiLeaveTarget) => {
-      if ((runningRef.current || activeRef.current) && !window.confirm(text.leaveConfirm)) return;
-      void leave(target);
-    };
-    registerLeaveHandler(handler);
-    return () => registerLeaveHandler(null);
-  }, [registerLeaveHandler, onLeave, text.leaveConfirm]);
 
   if (manualItem) {
     return (
@@ -640,7 +600,7 @@ export function MultiTaskPage({
               </div>
               {done ? (
                 <div className="batch-actions">
-                  <button className="secondary" type="button" onClick={() => item.outputMediaUrl ? setPreview({
+                  <button className="secondary" type="button" disabled={!item.outputMediaUrl && batchTaskActive} onClick={() => item.outputMediaUrl ? setPreview({
                     source: item.outputMediaUrl,
                     name: item.video.name,
                     width: item.metadata.width,

--- a/src/renderer/MultiTaskPage.tsx
+++ b/src/renderer/MultiTaskPage.tsx
@@ -127,7 +127,6 @@ export function MultiTaskPage({
   const rowRefs = useRef(new Map<string, HTMLElement>());
   const previousRects = useRef(new Map<string, DOMRect>());
   const optionsRef = useRef({ preRoll, postRoll, ballModelProfile });
-  optionsRef.current = { preRoll, postRoll, ballModelProfile };
 
   const isEnglish = language === 'en';
   const text = {

--- a/src/renderer/MultiTaskPage.tsx
+++ b/src/renderer/MultiTaskPage.tsx
@@ -115,11 +115,13 @@ export function MultiTaskPage({
   const [manualItemId, setManualItemId] = useState<string | null>(null);
   const [manualPoints, setManualPoints] = useState<Partial<Record<PointName, [number, number]>>>({});
   const [systemNotice, setSystemNotice] = useState<string | null>(null);
+  const [shutdownAfterCompletion, setShutdownAfterCompletion] = useState(false);
   const itemsRef = useRef(items);
   const activeRef = useRef<{ taskId: string | null; itemId: string; phase: ActivePhase } | null>(null);
   const runningRef = useRef(false);
   const cancelRequested = useRef(false);
   const autoCalibrationAvailableRef = useRef(true);
+  const shutdownAfterCompletionRef = useRef(false);
   const pendingTaskStartRef = useRef<Promise<string> | null>(null);
   const scheduleRef = useRef<() => void>(() => undefined);
   const rowRefs = useRef(new Map<string, HTMLElement>());
@@ -141,6 +143,8 @@ export function MultiTaskPage({
     start: isEnglish ? 'Start analysis and cutting' : '开始分析剪辑',
     calibrating: isEnglish ? 'Calibrating tables' : '正在自动标定',
     running: isEnglish ? 'Processing serially' : '正在串行处理',
+    shutdownAfterTask: isEnglish ? 'Shut down after this task' : '完成本任务后关机',
+    shutdownFailed: isEnglish ? 'Automatic shutdown failed. Please shut down manually.' : '自动关机失败，请手动关机。',
     calibrationTitle: isEnglish ? 'Calibrate the table' : '标定球桌',
     calibrationDescription: isEnglish
       ? 'Mark top-left, top-right, bottom-right, and bottom-left in order.'
@@ -223,9 +227,16 @@ export function MultiTaskPage({
       && item.processingStatus === 'waiting'
     ));
     if (!candidate) {
+      const completedSuccessfully = itemsRef.current.length > 0
+        && itemsRef.current.every((item) => item.processingStatus === 'done');
       runningRef.current = false;
       setRunning(false);
       onCompletableTasksFinished();
+      if (completedSuccessfully && shutdownAfterCompletionRef.current) {
+        shutdownAfterCompletionRef.current = false;
+        setShutdownAfterCompletion(false);
+        void window.ttcut.shutdownSystem().catch(() => setSystemNotice(text.shutdownFailed));
+      }
       return;
     }
     cancelRequested.current = false;
@@ -464,6 +475,11 @@ export function MultiTaskPage({
     scheduleRef.current();
   };
 
+  const toggleShutdownAfterCompletion = (enabled: boolean) => {
+    shutdownAfterCompletionRef.current = enabled;
+    setShutdownAfterCompletion(enabled);
+  };
+
   const cancel = async () => {
     const active = activeRef.current;
     if (!active?.taskId || active.phase === 'calibration') return;
@@ -643,14 +659,26 @@ export function MultiTaskPage({
           );
         })}
       </div>
-      <button
-        className="batch-start primary"
-        type="button"
-        disabled={running || calibrationBusy || !canStart}
-        onClick={start}
-      >
-        {activePhase === 'calibration' ? text.calibrating : running ? text.running : text.start}
-      </button>
+      <div className={`batch-launcher ${shutdownAfterCompletion ? 'shutdown-armed' : ''}`}>
+        <label className="batch-shutdown-option">
+          <input
+            type="checkbox"
+            checked={shutdownAfterCompletion}
+            disabled={!batchTaskActive}
+            onChange={(event) => toggleShutdownAfterCompletion(event.target.checked)}
+          />
+          <span>{text.shutdownAfterTask}</span>
+        </label>
+        <button
+          className="batch-start primary"
+          type="button"
+          disabled={running || calibrationBusy || !canStart}
+          onClick={start}
+        >
+          {activePhase === 'calibration' ? text.calibrating : running ? text.running : text.start}
+          {shutdownAfterCompletion && <span className="batch-shutdown-indicator" aria-hidden="true">⏻</span>}
+        </button>
+      </div>
       {preview && (
         <div className="modal-backdrop batch-preview-backdrop" onPointerDown={(event) => { if (event.target === event.currentTarget) setPreview(null); }}>
           <div className="modal batch-preview">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -329,7 +329,25 @@ td input { accent-color: var(--blue); }
 .batch-remove { width: 34px; height: 34px; border: 0; border-radius: 9px; background: transparent; color: var(--muted); cursor: pointer; font-size: 22px; }
 .batch-remove:hover { background: #fff0ef; color: #a1261f; }
 .batch-actions { display: flex; gap: 8px; justify-content: flex-end; }
-.batch-start { position: fixed; z-index: 20; right: 34px; bottom: 30px; min-height: 48px; padding: 0 24px; border-radius: 24px; box-shadow: 0 12px 32px rgba(45, 112, 220, .3); }
+.batch-launcher { position: fixed; z-index: 20; right: 34px; bottom: 30px; display: grid; justify-items: end; gap: 8px; }
+.batch-start { position: relative; min-height: 48px; padding: 0 24px; border-radius: 24px; box-shadow: 0 12px 32px rgba(45, 112, 220, .3); }
+.batch-shutdown-option {
+  min-height: 34px; padding: 0 12px; display: flex; align-items: center; gap: 7px;
+  border: 1px solid var(--line); border-radius: 7px; background: rgba(255, 255, 255, .97); box-shadow: 0 8px 20px rgba(0, 0, 0, .12);
+  color: var(--text); font-size: 12px; font-weight: 400; cursor: pointer; opacity: 0; pointer-events: none;
+  transform: translateY(14px) scale(.94); transform-origin: right bottom;
+  transition: opacity 150ms ease, transform 180ms cubic-bezier(.2, .9, .3, 1.2);
+}
+.batch-shutdown-option input { width: 14px; height: 14px; margin: 0; accent-color: var(--blue); cursor: pointer; }
+.batch-shutdown-option:has(input:disabled) { color: var(--muted); cursor: default; }
+.batch-shutdown-option input:disabled { cursor: default; }
+.batch-launcher:hover .batch-shutdown-option,
+.batch-launcher:has(.batch-start:focus-visible) .batch-shutdown-option,
+.batch-launcher:has(.batch-shutdown-option input:focus-visible) .batch-shutdown-option {
+  opacity: 1; pointer-events: auto; transform: translateY(0) scale(1);
+}
+.batch-launcher.shutdown-armed .batch-start { box-shadow: 0 0 0 2px rgba(194, 110, 26, .38), 0 12px 32px rgba(45, 112, 220, .3); }
+.batch-shutdown-indicator { display: inline-block; margin-left: 8px; font-size: 14px; line-height: 1; }
 .batch-system-notice { width: 100%; margin: 0 0 16px; }
 .multi-calibration-page { width: min(980px, 100%); margin: 0 auto; }
 .multi-calibration-page .multi-header { align-items: center; }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -118,5 +118,6 @@ export interface TTcutApi {
   toggleMaximize(): Promise<void>;
   close(): Promise<void>;
   confirmClose(action: 'exit' | 'minimize' | 'cancel'): Promise<void>;
+  shutdownSystem(): Promise<void>;
   onCloseRequested(listener: () => void): () => void;
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -29,6 +29,7 @@ export const IPC = {
   windowClose: 'window:close',
   windowConfirmClose: 'window:confirm-close',
   windowCloseRequested: 'window:close-requested',
+  systemShutdown: 'system:shutdown',
   logsReveal: 'logs:reveal',
   licensesOpen: 'licenses:open',
   externalOpen: 'external:open',

--- a/tests/app-workflow.test.tsx
+++ b/tests/app-workflow.test.tsx
@@ -177,6 +177,8 @@ describe('App workflow notices and multi-task entry', () => {
 
     expect(screen.getByRole('button', { name: '默认模型速度快，精准度一般。' })).toBeVisible();
     expect(screen.getByRole('button', { name: '新模型速度慢，准确度很高。' })).toBeVisible();
+    expect(screen.getByText('高精度双检测模型')).toBeVisible();
+    expect(screen.getByText('组件路径: C:\\models\\dual-ball-models\\1.0.0')).toBeVisible();
     expect(screen.queryByText('单视频和多任务统一使用所选档位。板数仍表示落台反弹数。')).toBeNull();
   });
 

--- a/tests/app-workflow.test.tsx
+++ b/tests/app-workflow.test.tsx
@@ -358,6 +358,13 @@ describe('App workflow notices and multi-task entry', () => {
         outputPath: 'C:\\video\\first_TTcut.mp4',
         outputName: 'first_TTcut.mp4',
         mediaUrl: 'ttcut-media://output',
+        timing: {
+          targetSeconds: 100,
+          actualSeconds: 100.05,
+          driftSeconds: 0.05,
+          allowedDriftSeconds: 0.1,
+          segmentCount: 1,
+        },
       },
     }));
     fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));

--- a/tests/app-workflow.test.tsx
+++ b/tests/app-workflow.test.tsx
@@ -74,6 +74,17 @@ function metadata(path: string): VideoMetadata {
   };
 }
 
+const calibration = {
+  video_width: 1280,
+  video_height: 720,
+  points: {
+    top_left: [300, 200] as [number, number],
+    top_right: [900, 200] as [number, number],
+    bottom_right: [1000, 600] as [number, number],
+    bottom_left: [200, 600] as [number, number],
+  },
+};
+
 describe('App workflow notices and multi-task entry', () => {
   let taskListener: ((event: AppEvent) => void) | null;
   let selectVideos: ReturnType<typeof vi.fn>;
@@ -102,6 +113,10 @@ describe('App workflow notices and multi-task entry', () => {
       selectVideos,
       probeVideo: vi.fn((path: string) => Promise.resolve(metadata(path))),
       startAutoCalibration: vi.fn().mockResolvedValue('calibration-task-1'),
+      startAnalysis: vi.fn().mockResolvedValue('analysis-task-1'),
+      startExport: vi.fn().mockResolvedValue('export-task-1'),
+      cancelTask: vi.fn().mockResolvedValue(undefined),
+      listHistory: vi.fn().mockResolvedValue([]),
       saveSettings: vi.fn((settings) => Promise.resolve(settings)),
       installDualBallModels: vi.fn().mockResolvedValue('dual-setup-task'),
     } as unknown as TTcutApi;
@@ -241,6 +256,110 @@ describe('App workflow notices and multi-task entry', () => {
     await screen.findByRole('heading', { name: '多任务剪辑' });
     await waitFor(() => expect(screen.getByText('first.mp4')).toBeVisible());
     expect(confirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: '设置' }));
+    expect(await screen.findByRole('heading', { name: '设置' })).toBeVisible();
+    expect(screen.getByText('first.mp4')).not.toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: '自动剪辑' }));
+    expect(await screen.findByText('first.mp4')).toBeVisible();
+    expect(window.ttcut.cancelTask).not.toHaveBeenCalled();
+  });
+
+  it('returns to an active single-video process across history and settings', async () => {
+    bootstrap.settings.language = 'en';
+    selectVideos.mockResolvedValue([{
+      path: 'C:\\video\\first.mp4', name: 'first.mp4', size: 100, mediaUrl: 'ttcut-media://first',
+    }]);
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: /Choose MP4 \/ MOV videos/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Start analysis' }));
+    expect(await screen.findByRole('heading', { name: 'Analyzing video' })).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'History' }));
+    expect(await screen.findByRole('heading', { name: 'History' })).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));
+    expect(await screen.findByRole('heading', { name: 'Analyzing video' })).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    expect(await screen.findByRole('heading', { name: 'Settings' })).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));
+    expect(await screen.findByRole('heading', { name: 'Analyzing video' })).toBeVisible();
+    expect(window.ttcut.startAnalysis).toHaveBeenCalledTimes(1);
+    expect(window.ttcut.cancelTask).not.toHaveBeenCalled();
+  });
+
+  it('returns home when analysis finishes while another page is open', async () => {
+    bootstrap.settings.language = 'en';
+    const selected = {
+      path: 'C:\\video\\first.mp4', name: 'first.mp4', size: 100, mediaUrl: 'ttcut-media://first',
+    };
+    selectVideos.mockResolvedValue([selected]);
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: /Choose MP4 \/ MOV videos/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Start analysis' }));
+    await screen.findByRole('heading', { name: 'Analyzing video' });
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+
+    act(() => taskListener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-1',
+      analysisId: '11111111-1111-4111-8111-111111111111',
+      calibration,
+      data: {
+        schema_version: 1,
+        video: metadata(selected.path),
+        rallies: [{ id: 'rally_001', index: 1, bounce_count: 5, start_time_seconds: 1, end_time_seconds: 5 }],
+        calibration,
+      },
+    }));
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));
+
+    expect(await screen.findByRole('heading', { name: 'Choose match videos' })).toBeVisible();
+    expect(screen.queryByRole('heading', { name: 'Choose a cutting mode' })).toBeNull();
+  });
+
+  it('returns to active cutting but goes home after export completes', async () => {
+    bootstrap.settings.language = 'en';
+    const selected = {
+      path: 'C:\\video\\first.mp4', name: 'first.mp4', size: 100, mediaUrl: 'ttcut-media://first',
+    };
+    selectVideos.mockResolvedValue([selected]);
+    render(<App />);
+    fireEvent.click(await screen.findByRole('button', { name: /Choose MP4 \/ MOV videos/ }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Start analysis' }));
+    act(() => taskListener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-1',
+      analysisId: '11111111-1111-4111-8111-111111111111',
+      calibration,
+      data: {
+        schema_version: 1,
+        video: metadata(selected.path),
+        rallies: [{ id: 'rally_001', index: 1, bounce_count: 5, start_time_seconds: 1, end_time_seconds: 5 }],
+        calibration,
+      },
+    }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Start cutting' }));
+    expect(await screen.findByRole('heading', { name: 'Preparing' })).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));
+    expect(await screen.findByRole('heading', { name: 'Preparing' })).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+    act(() => taskListener?.({
+      type: 'export-result',
+      taskId: 'export-task-1',
+      data: {
+        taskId: 'export-task-1',
+        analysisId: '11111111-1111-4111-8111-111111111111',
+        outputPath: 'C:\\video\\first_TTcut.mp4',
+        outputName: 'first_TTcut.mp4',
+        mediaUrl: 'ttcut-media://output',
+      },
+    }));
+    fireEvent.click(screen.getByRole('button', { name: 'Auto Cut' }));
+    expect(await screen.findByRole('heading', { name: 'Choose match videos' })).toBeVisible();
   });
 
   it('keeps the export support prompt visible across pages until it is rejected', async () => {

--- a/tests/multi-task-page.test.tsx
+++ b/tests/multi-task-page.test.tsx
@@ -70,6 +70,7 @@ describe('multi-task clipping', () => {
       acceptDroppedVideo: vi.fn(),
       pathForDroppedFile: vi.fn(),
       cancelTask: vi.fn().mockResolvedValue(undefined),
+      shutdownSystem: vi.fn().mockResolvedValue(undefined),
       deleteAnalysis: vi.fn().mockResolvedValue(undefined),
       revealOutput: vi.fn().mockResolvedValue(undefined),
     } as unknown as TTcutApi;
@@ -273,6 +274,7 @@ describe('multi-task clipping', () => {
       />,
     );
     await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
     act(() => listener?.({
       type: 'error',
       taskId: 'calibration-task-1',
@@ -314,6 +316,51 @@ describe('multi-task clipping', () => {
 
     await waitFor(() => expect(onCompletableTasksFinished).toHaveBeenCalledTimes(1));
     expect(screen.getByText('标定失败')).toBeVisible();
+    expect(window.ttcut.shutdownSystem).not.toHaveBeenCalled();
+  });
+
+  it('shuts down once after every item in an armed batch succeeds', async () => {
+    const onCompletableTasksFinished = vi.fn();
+    render(
+      <MultiTaskPage
+        initialVideos={videos}
+        preRoll={2.5}
+        postRoll={1}
+        exportStrategy="compatible"
+        onOpenAnalysis={vi.fn()}
+        onCompletableTasksFinished={onCompletableTasksFinished}
+      />,
+    );
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(1));
+    await finishCalibration('calibration-task-1');
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(2));
+    await finishCalibration('calibration-task-2');
+
+    for (const group of screen.getAllByRole('group')) {
+      fireEvent.click(within(group).getAllByRole('button')[2]!);
+    }
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
+    fireEvent.click(document.querySelector('.batch-start')!);
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    act(() => listener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-1',
+      analysisId: '11111111-1111-4111-8111-111111111111',
+      calibration,
+      data: analysis(videos[0]!.path),
+    }));
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(2));
+    act(() => listener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-2',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      calibration,
+      data: analysis(videos[1]!.path),
+    }));
+
+    await waitFor(() => expect(window.ttcut.shutdownSystem).toHaveBeenCalledTimes(1));
+    expect(onCompletableTasksFinished).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('checkbox', { name: '完成本任务后关机' })).not.toBeChecked();
   });
 
   it('turns all remaining items into manual calibration when the model is unavailable', async () => {

--- a/tests/multi-task-page.test.tsx
+++ b/tests/multi-task-page.test.tsx
@@ -414,30 +414,87 @@ describe('multi-task clipping', () => {
     expect(startAnalysis.mock.calls[1]?.[0]).toMatchObject({ videoPath: videos[1]!.path });
   });
 
-  it('confirms and cancels the active worker before leaving the batch', async () => {
-    let leaveHandler: ((target: 'auto' | 'history' | 'settings') => void) | null = null;
-    const onLeave = vi.fn();
-    const registerLeaveHandler = (handler: typeof leaveHandler) => { leaveHandler = handler; };
+  it('continues the batch after cancellation without retrying the cancelled item', async () => {
+    const onTaskStateChange = vi.fn();
     render(
       <MultiTaskPage
         initialVideos={videos}
         preRoll={2.5}
         postRoll={1}
         onOpenAnalysis={vi.fn()}
-        registerLeaveHandler={registerLeaveHandler}
-        onLeave={onLeave}
+        onTaskStateChange={onTaskStateChange}
       />,
     );
     await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(document.querySelector('.batch-cover.processing')).not.toBeNull());
+    await finishCalibration('calibration-task-1');
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(2));
+    await finishCalibration('calibration-task-2');
 
-    vi.spyOn(window, 'confirm').mockReturnValueOnce(false).mockReturnValueOnce(true);
-    act(() => leaveHandler?.('history'));
-    expect(window.ttcut.cancelTask).not.toHaveBeenCalled();
-    expect(onLeave).not.toHaveBeenCalled();
+    for (const group of screen.getAllByRole('group')) {
+      fireEvent.click(within(group).getAllByRole('button')[2]!);
+    }
+    fireEvent.click(document.querySelector('.batch-start')!);
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    fireEvent.click(document.querySelector('.batch-cover.processing')!);
+    await waitFor(() => expect(window.ttcut.cancelTask).toHaveBeenCalledWith('analysis-task-1'));
 
-    act(() => leaveHandler?.('history'));
-    await waitFor(() => expect(window.ttcut.cancelTask).toHaveBeenCalledWith('calibration-task-1'));
-    await waitFor(() => expect(onLeave).toHaveBeenCalledWith('history'));
+    act(() => listener?.({
+      type: 'error', taskId: 'analysis-task-1', code: 'WORKER_EXITED', message: 'cancelled',
+    }));
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(2));
+    act(() => listener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-2',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      calibration,
+      data: analysis(videos[1]!.path),
+    }));
+
+    await waitFor(() => expect(onTaskStateChange).toHaveBeenLastCalledWith(false));
+    expect(startAnalysis).toHaveBeenCalledTimes(2);
+  });
+
+  it('freezes processing settings for the lifetime of a batch', async () => {
+    const view = render(
+      <MultiTaskPage
+        initialVideos={videos}
+        preRoll={2.5}
+        postRoll={1}
+        exportStrategy="compatible"
+        ballModelProfile="tracknet_v1"
+        onOpenAnalysis={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(1));
+    await finishCalibration('calibration-task-1');
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(2));
+    await finishCalibration('calibration-task-2');
+
+    view.rerender(
+      <MultiTaskPage
+        initialVideos={videos}
+        preRoll={5}
+        postRoll={4}
+        exportStrategy="fast_segmented"
+        ballModelProfile="uplifting_dual_v1"
+        onOpenAnalysis={vi.fn()}
+      />,
+    );
+    fireEvent.click(document.querySelector('.batch-start')!);
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    expect(startAnalysis.mock.calls[0]?.[0]).toMatchObject({ ballModelProfile: 'tracknet_v1' });
+
+    act(() => listener?.({
+      type: 'analysis-result',
+      taskId: 'analysis-task-1',
+      analysisId: '11111111-1111-4111-8111-111111111111',
+      calibration,
+      data: analysis(videos[0]!.path),
+    }));
+    await waitFor(() => expect(startExport).toHaveBeenCalledTimes(1));
+    expect(startExport.mock.calls[0]?.[0]).toMatchObject({
+      export_strategy: 'compatible',
+      selection: { pre_roll_seconds: 2.5, post_roll_seconds: 1 },
+    });
   });
 });

--- a/tests/multi-task-page.test.tsx
+++ b/tests/multi-task-page.test.tsx
@@ -326,7 +326,6 @@ describe('multi-task clipping', () => {
         initialVideos={videos}
         preRoll={2.5}
         postRoll={1}
-        exportStrategy="compatible"
         onOpenAnalysis={vi.fn()}
         onCompletableTasksFinished={onCompletableTasksFinished}
       />,
@@ -507,7 +506,6 @@ describe('multi-task clipping', () => {
         initialVideos={videos}
         preRoll={2.5}
         postRoll={1}
-        exportStrategy="compatible"
         ballModelProfile="tracknet_v1"
         onOpenAnalysis={vi.fn()}
       />,
@@ -522,7 +520,6 @@ describe('multi-task clipping', () => {
         initialVideos={videos}
         preRoll={5}
         postRoll={4}
-        exportStrategy="fast_segmented"
         ballModelProfile="uplifting_dual_v1"
         onOpenAnalysis={vi.fn()}
       />,
@@ -540,7 +537,6 @@ describe('multi-task clipping', () => {
     }));
     await waitFor(() => expect(startExport).toHaveBeenCalledTimes(1));
     expect(startExport.mock.calls[0]?.[0]).toMatchObject({
-      export_strategy: 'compatible',
       selection: { pre_roll_seconds: 2.5, post_roll_seconds: 1 },
     });
   });

--- a/tests/system-power.test.ts
+++ b/tests/system-power.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { requestSystemShutdown } from '../src/main/system-power';
+
+describe('system shutdown', () => {
+  it('waits for active work before invoking the Windows shutdown command', async () => {
+    let busyChecks = 0;
+    const run = vi.fn().mockResolvedValue(undefined);
+    const wait = vi.fn().mockResolvedValue(undefined);
+
+    await requestSystemShutdown({
+      platform: 'win32',
+      isBusy: () => busyChecks++ < 2,
+      wait,
+      run,
+    });
+
+    expect(wait).toHaveBeenCalledTimes(2);
+    expect(wait).toHaveBeenCalledWith(50);
+    expect(run).toHaveBeenCalledWith('shutdown.exe', ['/s', '/t', '0']);
+  });
+
+  it('rejects unsupported platforms without invoking a command', async () => {
+    const run = vi.fn();
+    await expect(requestSystemShutdown({ platform: 'linux', run }))
+      .rejects.toThrow('SYSTEM_SHUTDOWN_UNSUPPORTED');
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('does not shut down while active work remains past the wait limit', async () => {
+    const run = vi.fn();
+    const wait = vi.fn().mockResolvedValue(undefined);
+    await expect(requestSystemShutdown({
+      platform: 'win32',
+      isBusy: () => true,
+      wait,
+      run,
+    })).rejects.toThrow('TASK_BUSY');
+    expect(wait).toHaveBeenCalledTimes(200);
+    expect(run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Keep the active single-video or batch workflow alive while navigating between Auto Cut, History, and Settings, and prevent starting conflicting setup or history actions.
- Add a compact hover control that can shut down Windows after every item in an armed batch completes successfully, with failure and busy-state safeguards.
- Rename the optional dual model component to the high-accuracy dual detection model and display its installed component path.

## Impact

Users can leave and return to an in-progress workflow without losing the processing screen. Batch users may opt into automatic shutdown without allowing failed, cancelled, or manually blocked items to trigger it.

## Validation

- `npm run typecheck`
- `npm test -- --maxWorkers=1` (`166` passed, `10` skipped)
- `npm run package`
- `git diff --check origin/develop...HEAD`