### PR TITLE
Fix abnormal frame duration exports

### DIFF
--- a/src/main/export.ts
+++ b/src/main/export.ts
@@ -50,6 +50,7 @@ import {
 } from './processes';
 
 const lastExportProgress = new Map<string, number>();
+const AV_SYNC_TOLERANCE_SECONDS = 0.1;
 
 type ExportTimingExpectation = {
   targetSeconds: number;
@@ -73,6 +74,21 @@ class ExportDurationMismatchError extends Error {
       + ` segments=${timing.segmentCount}`,
     );
     this.name = 'ExportDurationMismatchError';
+  }
+}
+
+class ExportAvSyncMismatchError extends Error {
+  readonly exportCode = 'EXPORT_AV_SYNC_MISMATCH';
+
+  constructor(videoSeconds: number, audioSeconds: number) {
+    const deltaSeconds = Math.abs(videoSeconds - audioSeconds);
+    super(
+      `EXPORT_AV_SYNC_MISMATCH: video=${videoSeconds.toFixed(6)}`
+      + ` audio=${audioSeconds.toFixed(6)}`
+      + ` delta=${deltaSeconds.toFixed(6)}`
+      + ` allowed=${AV_SYNC_TOLERANCE_SECONDS.toFixed(6)}`,
+    );
+    this.name = 'ExportAvSyncMismatchError';
   }
 }
 
@@ -326,8 +342,12 @@ export async function validateExportOutput(
   }
   if (metadata.video_duration_seconds !== null && metadata.video_duration_seconds !== undefined
     && metadata.audio_duration_seconds !== null && metadata.audio_duration_seconds !== undefined
-    && Math.abs(metadata.video_duration_seconds - metadata.audio_duration_seconds) > 0.1) {
-    throw new Error('EXPORT_AV_SYNC_MISMATCH');
+    && Math.abs(metadata.video_duration_seconds - metadata.audio_duration_seconds)
+      > AV_SYNC_TOLERANCE_SECONDS) {
+    throw new ExportAvSyncMismatchError(
+      metadata.video_duration_seconds,
+      metadata.audio_duration_seconds,
+    );
   }
   const timestampTolerance = exportTimestampTolerance(metadata);
   const startTimes = [
@@ -478,7 +498,11 @@ async function executeFastSegmented(
         analysisVideo,
         'normalized',
       );
-      encodedSegmentDurations.push(validation.metadata.duration_seconds);
+      encodedSegmentDurations.push(
+        analysisVideo.audio_codec === null
+          ? group.end - group.start
+          : validation.metadata.duration_seconds,
+      );
       await logExportTiming(taskId, `Fast segment ${index + 1} timing`, validation.timing, analysisVideo);
       const signature = await probeStreamSignature(segmentPath, components.ffprobe);
       if (!signature.video.extradataHash) throw new Error('EXPORT_SEGMENT_FAILED');
@@ -492,7 +516,10 @@ async function executeFastSegmented(
   }
   assertExportNotCancelled(taskId);
   const manifest = path.join(tempDirectory, 'segments.ffconcat');
-  await writeFile(manifest, buildConcatManifest(segmentNames), 'utf8');
+  const silentSegmentDurations = analysisVideo.audio_codec === null
+    ? groups.map((group) => group.end - group.start)
+    : undefined;
+  await writeFile(manifest, buildConcatManifest(segmentNames, silentSegmentDurations), 'utf8');
   try {
     await runFfmpeg(
       window,

--- a/src/main/media-plan.ts
+++ b/src/main/media-plan.ts
@@ -134,7 +134,7 @@ export function buildTrimFilter(
     const group = groups[0]!;
     parts.push(
       `[0:v:0]trim=start=${group.start.toFixed(6)}:end=${group.end.toFixed(6)},`
-      + `setpts=PTS-STARTPTS,setsar=sar=${sar}[vout]`,
+      + `setpts=PTS-STARTPTS:strip_fps=1,setsar=sar=${sar}[vout]`,
     );
     if (hasAudio) {
       parts.push(
@@ -152,7 +152,7 @@ export function buildTrimFilter(
     groups.forEach((group, index) => {
       parts.push(
         `[vsrc${index}]trim=start=${group.start.toFixed(6)}:end=${group.end.toFixed(6)},`
-        + `setpts=PTS-STARTPTS[v${index}]`,
+        + `setpts=PTS-STARTPTS:strip_fps=1[v${index}]`,
       );
       if (hasAudio) {
         parts.push(
@@ -229,9 +229,18 @@ function escapeConcatPath(value: string): string {
   return value.replaceAll('\\', '/').replaceAll("'", "'\\''");
 }
 
-export function buildConcatManifest(relativePaths: readonly string[]): string {
+export function buildConcatManifest(
+  relativePaths: readonly string[],
+  durationsSeconds?: readonly number[],
+): string {
+  if (durationsSeconds && durationsSeconds.length !== relativePaths.length) {
+    throw new Error('CONCAT_DURATION_COUNT_MISMATCH');
+  }
   return `ffconcat version 1.0\n${relativePaths
-    .map((relativePath) => `file '${escapeConcatPath(relativePath)}'`)
+    .flatMap((relativePath, index) => [
+      `file '${escapeConcatPath(relativePath)}'`,
+      ...(durationsSeconds ? [`duration ${durationsSeconds[index]!.toFixed(6)}`] : []),
+    ])
     .join('\n')}\n`;
 }
 

--- a/tests/export-validation.test.ts
+++ b/tests/export-validation.test.ts
@@ -123,6 +123,28 @@ describe('export timestamp validation', () => {
     )).rejects.toThrow('EXPORT_TIMESTAMP_INVALID');
   });
 
+  it('reports A/V durations and preserves the synchronization error code', async () => {
+    state.probeVideo.mockResolvedValue({
+      ...source,
+      path: output,
+      duration_seconds: 2.25,
+      video_duration_seconds: 2.25,
+      audio_duration_seconds: 2,
+    });
+
+    const validation = validateExportOutput(
+      output,
+      { targetSeconds: 2, segmentCount: 1 },
+      source,
+    );
+    await expect(validation).rejects.toMatchObject({
+      exportCode: 'EXPORT_AV_SYNC_MISMATCH',
+    });
+    await expect(validation).rejects.toThrow(
+      'EXPORT_AV_SYNC_MISMATCH: video=2.250000 audio=2.000000 delta=0.250000 allowed=0.100000',
+    );
+  });
+
   it('accepts a physically normalized portrait output without copied rotation metadata', async () => {
     const rotatedSource: VideoMetadata = {
       ...source,

--- a/tests/fast-segmented-export.integration.test.ts
+++ b/tests/fast-segmented-export.integration.test.ts
@@ -28,6 +28,10 @@ const cases = [
     ffprobe: process.env.TTCUT_X264_FFPROBE_INTEGRATION,
   },
 ];
+const syntheticFfmpeg = process.env.TTCUT_X264_FFMPEG_INTEGRATION;
+const syntheticFfprobe = process.env.TTCUT_X264_FFPROBE_INTEGRATION;
+const syntheticEnabled = Boolean(syntheticFfmpeg && syntheticFfprobe);
+const nullDevice = process.platform === 'win32' ? 'NUL' : '/dev/null';
 
 const groups: CutGroup[] = [
   { rallyIds: ['rally_001'], rawStart: 8, rawEnd: 10, start: 6.108, end: 10.108 },
@@ -120,6 +124,41 @@ function expectMonotonic(values: readonly number[]): void {
   for (let index = 1; index < values.length; index += 1) {
     expect(values[index]!).toBeGreaterThanOrEqual(values[index - 1]!);
   }
+}
+
+function expectStrictlyIncreasing(values: readonly number[]): void {
+  for (let index = 1; index < values.length; index += 1) {
+    expect(values[index]!).toBeGreaterThan(values[index - 1]!);
+  }
+}
+
+function probeVideoPacketDurations(ffprobe: string, file: string): number[] {
+  const data = JSON.parse(run(ffprobe, [
+    '-v', 'error', '-select_streams', 'v:0', '-show_packets',
+    '-show_entries', 'packet=duration_time', '-of', 'json', file,
+  ])) as { packets?: Array<{ duration_time?: string }> };
+  return (data.packets ?? [])
+    .map((packet) => Number(packet.duration_time))
+    .filter(Number.isFinite);
+}
+
+function streamDuration(data: ReturnType<typeof probe>, type: 'video' | 'audio'): number {
+  return Number(data.streams.find((stream) => stream.codec_type === type)?.duration);
+}
+
+function createAbnormalFrameDurationSource(ffmpeg: string, output: string): void {
+  run(ffmpeg, [
+    '-hide_banner', '-y',
+    '-f', 'lavfi', '-i', 'testsrc2=size=320x240:rate=30:duration=4',
+    '-f', 'lavfi', '-i', 'sine=frequency=440:sample_rate=48000:duration=4',
+    '-filter_complex',
+    "[0:v]setpts='if(eq(N,0),0,PREV_OUTPTS+if(eq(mod(N,9),0),0.2665/TB,0.0001/TB))'[v]",
+    '-map', '[v]', '-map', '1:a:0',
+    '-fps_mode', 'vfr',
+    '-c:v', 'libx264', '-preset', 'ultrafast', '-g', '60',
+    '-c:a', 'aac', '-b:a', '128k', '-ar', '48000', '-ac', '2',
+    '-shortest', output,
+  ]);
 }
 
 function verifyVfr73IntervalExport(
@@ -251,11 +290,81 @@ describe.each(cases)('fast segmented export with $encoder', ({ encoder, ffmpeg, 
     if (!ffmpeg || !ffprobe) throw new Error('Integration environment is incomplete.');
     verifyVfr73IntervalExport(encoder, ffmpeg, ffprobe);
   }, 240_000);
-});
 
-const syntheticFfmpeg = process.env.TTCUT_X264_FFMPEG_INTEGRATION;
-const syntheticFfprobe = process.env.TTCUT_X264_FFPROBE_INTEGRATION;
-const syntheticEnabled = Boolean(syntheticFfmpeg && syntheticFfprobe);
+  it.skipIf(!syntheticFfmpeg || !syntheticFfprobe || !ffmpeg || !ffprobe)(
+    'clears abnormal frame durations before encoding',
+    () => {
+      if (!syntheticFfmpeg || !syntheticFfprobe || !ffmpeg || !ffprobe) {
+        throw new Error('Integration environment is incomplete.');
+      }
+      const directory = mkdtempSync(path.join(tmpdir(), `ttcut-frame-duration-${encoder}-`));
+      try {
+        const source = path.join(directory, 'source-abnormal-duration.mp4');
+        createAbnormalFrameDurationSource(syntheticFfmpeg, source);
+        const sourceDurations = probeVideoPacketDurations(syntheticFfprobe, source);
+        expect(Math.min(...sourceDurations)).toBeLessThanOrEqual(1 / 30 + 0.001);
+        expect(Math.max(...sourceDurations)).toBeGreaterThanOrEqual(0.19);
+
+        const metadata = {
+          ...sourceMetadata(source, probe(syntheticFfprobe, source)),
+          variable_frame_rate: true,
+        };
+        const group: CutGroup = {
+          rallyIds: ['rally_001'], rawStart: 0, rawEnd: 0.3, start: 0, end: 0.3,
+        };
+        const fixedOutput = path.join(directory, 'fixed.mp4');
+        const fixedArgs = buildSegmentReencodeArgs(
+          source,
+          fixedOutput,
+          group,
+          0,
+          metadata,
+          encoder,
+        );
+        const filterIndex = fixedArgs.indexOf('-filter_complex') + 1;
+        expect(fixedArgs[filterIndex]).toContain('setpts=PTS-STARTPTS:strip_fps=1');
+
+        const legacyOutput = path.join(directory, 'legacy.mp4');
+        const legacyArgs = [...fixedArgs];
+        legacyArgs[filterIndex] = legacyArgs[filterIndex]!.replace(':strip_fps=1', '');
+        legacyArgs[legacyArgs.length - 1] = legacyOutput;
+        run(ffmpeg, legacyArgs);
+        const legacy = probe(ffprobe, legacyOutput);
+        expect(Math.abs(streamDuration(legacy, 'video') - streamDuration(legacy, 'audio')))
+          .toBeGreaterThan(0.1);
+
+        run(ffmpeg, fixedArgs);
+        const fixed = probe(ffprobe, fixedOutput);
+        const video = fixed.streams.find((stream) => stream.codec_type === 'video');
+        const audio = fixed.streams.find((stream) => stream.codec_type === 'audio');
+        expect(video?.codec_name).toBe('h264');
+        expect(audio?.codec_name).toBe('aac');
+        expect(video?.width).toBe(320);
+        expect(video?.height).toBe(240);
+        expect(Math.abs(Number(fixed.format.duration) - (group.end - group.start)))
+          .toBeLessThanOrEqual(0.1);
+        expect(Math.abs(streamDuration(fixed, 'video') - streamDuration(fixed, 'audio')))
+          .toBeLessThanOrEqual(0.1);
+
+        const videoPackets = probePacketTimes(ffprobe, fixedOutput, 'v:0');
+        const audioPackets = probePacketTimes(ffprobe, fixedOutput, 'a:0');
+        expectStrictlyIncreasing(videoPackets.map((packet) => packet.dts));
+        expectStrictlyIncreasing(audioPackets.map((packet) => packet.dts));
+        run(ffmpeg, [
+          '-hide_banner', '-v', 'error', '-i', fixedOutput,
+          '-map', '0:v:0', '-an', '-pix_fmt', 'yuv420p', '-f', 'rawvideo', nullDevice,
+        ]);
+        run(ffmpeg, [
+          '-hide_banner', '-v', 'error', '-i', fixedOutput,
+          '-map', '0:a:0', '-vn', '-c:a', 'pcm_s16le', '-f', 's16le', nullDevice,
+        ]);
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
+});
 
 describe.skipIf(!syntheticEnabled)('fast segmented timestamp repair with generated media', () => {
   it('joins separately encoded 44.1 kHz AAC segments without DTS regressions', () => {
@@ -407,7 +516,11 @@ describe.skipIf(!syntheticEnabled)('fast segmented timestamp repair with generat
       });
       const manifest = path.join(directory, 'segments.ffconcat');
       const output = path.join(directory, 'joined.mp4');
-      writeFileSync(manifest, buildConcatManifest(names), 'utf8');
+      writeFileSync(
+        manifest,
+        buildConcatManifest(names, selectedGroups.map((group) => group.end - group.start)),
+        'utf8',
+      );
       const concat = runWithStderr(
         syntheticFfmpeg,
         buildConcatArgs(manifest, output, metadata),

--- a/tests/media-plan.test.ts
+++ b/tests/media-plan.test.ts
@@ -72,10 +72,11 @@ describe('media export planning', () => {
   it('builds a single concat graph for multiple groups', () => {
     const second = { ...oneGroup, rallyIds: ['rally_002'], rawStart: 20, rawEnd: 22, start: 19, end: 24 };
     const args = buildReencodeArgs(metadata.path, 'out.mp4', [oneGroup, second], metadata);
-    const filter = args[args.indexOf('-filter_complex') + 1];
+    const filter = args[args.indexOf('-filter_complex') + 1]!;
     expect(filter).toContain('split=2');
     expect(filter).toContain('asplit=2');
     expect(filter).toContain('concat=n=2:v=1:a=1');
+    expect(filter.match(/setpts=PTS-STARTPTS:strip_fps=1/g)).toHaveLength(2);
     expect(expectedOutputDuration([oneGroup, second])).toBe(11);
   });
 
@@ -128,8 +129,12 @@ describe('media export planning', () => {
       ]);
       const filter = args[args.indexOf('-filter_complex') + 1];
       expect(filter).toContain('trim=start=3.000000:end=9.000000');
+      expect(filter).toContain('setpts=PTS-STARTPTS:strip_fps=1');
       expect(filter).toContain('atrim=start=3.000000:end=9.000000');
       expect(args).toContain(encoder);
+      expect(args.slice(args.indexOf('-fps_mode'), args.indexOf('-fps_mode') + 2))
+        .toEqual(['-fps_mode', 'vfr']);
+      expect(args).not.toContain('-r');
     },
   );
 
@@ -160,6 +165,14 @@ describe('media export planning', () => {
       '-avoid_negative_ts', 'auto',
     ]));
     expect(args).not.toEqual(expect.arrayContaining(['-c', 'copy']));
+  });
+
+  it('writes explicit durations for silent segment concatenation', () => {
+    expect(buildConcatManifest(['one.mp4', 'two.mp4'], [1, 2.5])).toBe(
+      "ffconcat version 1.0\nfile 'one.mp4'\nduration 1.000000\n"
+      + "file 'two.mp4'\nduration 2.500000\n",
+    );
+    expect(() => buildConcatManifest(['one.mp4'], [])).toThrow('CONCAT_DURATION_COUNT_MISMATCH');
   });
 
   it('does not add audio concat options for silent segments', () => {


### PR DESCRIPTION
Fixes export A/V sync failures caused by abnormal input frame durations retained by newer FFmpeg setpts behavior. Applies strip_fps=1 across x264 and OpenH264 trim paths, preserves VFR, improves validation diagnostics, and adds regression/integration coverage. Validation: npm run typecheck; full npm test (37 files, 168 passed, 12 skipped); dual-component integration; full source-video export with x264 and FFmpeg 8.1/OpenH264, including decode, DTS, A/V delta, duration, and SSIM checks.