### PR TITLE
Fix CPU export keyframe probe timeout

### DIFF
--- a/scripts/build-analysis-runtime.mjs
+++ b/scripts/build-analysis-runtime.mjs
@@ -129,7 +129,6 @@ const selfTest = spawnSync(python, ['-c', selfTestCode], {
   cwd: target,
   encoding: 'utf8',
   windowsHide: true,
-  timeout: 120_000,
 });
 if (selfTest.status !== 0) throw new Error(`Runtime self-test failed: ${selfTest.stderr || selfTest.stdout}`);
 const versions = JSON.parse(selfTest.stdout.trim());

--- a/src/main/component-manager.ts
+++ b/src/main/component-manager.ts
@@ -562,7 +562,7 @@ export async function startMediaComponentInstall(window: BrowserWindow, consent:
       if (signal.aborted) throw Object.assign(new Error('SETUP_CANCELLED'), { name: 'AbortError' });
       await mkdir(staging, { recursive: true });
       sendProgress(window, taskId, 'extract', 80);
-      await runProcess('tar.exe', ['-xf', download, '-C', staging], { timeoutMs: 120_000 });
+      await runProcess('tar.exe', ['-xf', download, '-C', staging], { signal });
       const extracted = path.join(staging, catalog.ffmpeg.archive_root);
       const normalized = path.join(staging, catalog.ffmpeg.install_directory);
       if (!await exists(extracted)) throw new Error('COMPONENT_ARCHIVE_LAYOUT_MISMATCH');
@@ -646,7 +646,7 @@ export async function startDualBallModelsInstall(window: BrowserWindow, consent:
       ], {
         cwd: cudaComponents.worker,
         env: { ...process.env, PYTHONPATH: cudaComponents.worker, PYTHONUTF8: '1' },
-        timeoutMs: 120_000,
+        signal,
       });
       sendProgress(window, taskId, 'install', 94);
       await commitComponentDirectories(staging, [modelSet.install_directory], taskId);
@@ -760,7 +760,7 @@ async function prepareImportedDualModels(
   ], {
     cwd: cudaComponents.worker,
     env: { ...process.env, PYTHONPATH: cudaComponents.worker, PYTHONUTF8: '1' },
-    timeoutMs: 120_000,
+    signal,
   });
   if (signal.aborted) throw Object.assign(new Error('SETUP_CANCELLED'), { name: 'AbortError' });
 }

--- a/src/main/export.ts
+++ b/src/main/export.ts
@@ -333,10 +333,11 @@ export async function validateExportOutput(
   expectation: ExportTimingExpectation,
   source: VideoMetadata,
   orientation: 'preserved' | 'normalized' = 'preserved',
+  signal?: AbortSignal,
 ): Promise<ExportValidationResult> {
   const info = await stat(output);
   if (!info.isFile() || info.size < 1024) throw new Error('EXPORT_INVALID');
-  const metadata = await probeVideo(output);
+  const metadata = await probeVideo(output, signal);
   if (metadata.width !== source.width || metadata.height !== source.height) {
     throw new Error('EXPORT_RESOLUTION_MISMATCH');
   }
@@ -412,20 +413,40 @@ async function logExportTiming(
   );
 }
 
+async function probeExportKeyframes(
+  taskId: string,
+  videoPath: string,
+  ffprobe: string,
+  signal?: AbortSignal,
+): Promise<number[]> {
+  const started = Date.now();
+  await logLine(taskId, 'INFO', 'Keyframe packet probe started');
+  const keyframes = await probeKeyframes(videoPath, ffprobe, signal);
+  await logLine(
+    taskId,
+    'INFO',
+    `Keyframe packet probe complete: count=${keyframes.length} elapsedMs=${Date.now() - started}`,
+  );
+  return keyframes;
+}
+
 async function streamCopyEligibility(
+  taskId: string,
   videoPath: string,
   groups: readonly CutGroup[],
   metadata: VideoMetadata,
   ffprobe: string,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   if (groups.length !== 1) return false;
   try {
     const [keyframes, audioBoundaries] = await Promise.all([
-      probeKeyframes(videoPath, ffprobe),
-      metadata.audio_codec === null ? Promise.resolve([]) : probeAudioPacketBoundaries(videoPath, ffprobe),
+      probeExportKeyframes(taskId, videoPath, ffprobe, signal),
+      metadata.audio_codec === null ? Promise.resolve([]) : probeAudioPacketBoundaries(videoPath, ffprobe, signal),
     ]);
     return canUseStreamCopy(groups, keyframes, audioBoundaries, metadata);
   } catch {
+    assertExportNotCancelled(taskId);
     return false;
   }
 }
@@ -464,8 +485,9 @@ async function executeFastSegmented(
   groups: readonly CutGroup[],
   partial: string,
   tempDirectory: string,
+  signal?: AbortSignal,
 ): Promise<number[]> {
-  const keyframes = await probeKeyframes(analysisVideo.path, components.ffprobe);
+  const keyframes = await probeExportKeyframes(taskId, analysisVideo.path, components.ffprobe, signal);
   assertExportNotCancelled(taskId);
   const signatures: StreamSignature[] = [];
   const segmentNames: string[] = [];
@@ -504,6 +526,7 @@ async function executeFastSegmented(
         { targetSeconds: group.end - group.start, segmentCount: 1 },
         analysisVideo,
         'normalized',
+        signal,
       );
       encodedSegmentDurations.push(
         analysisVideo.audio_codec === null
@@ -511,7 +534,7 @@ async function executeFastSegmented(
           : validation.metadata.duration_seconds,
       );
       await logExportTiming(taskId, `Fast segment ${index + 1} timing`, validation.timing, analysisVideo);
-      const signature = await probeStreamSignature(segmentPath, components.ffprobe);
+      const signature = await probeStreamSignature(segmentPath, components.ffprobe, signal);
       if (!signature.video.extradataHash) throw new Error('EXPORT_SEGMENT_FAILED');
       if (signatures.length > 0 && !sameStreamSignature(signatures[0]!, signature)) {
         throw new Error('EXPORT_SEGMENT_INCOMPATIBLE');
@@ -554,8 +577,9 @@ async function executeFastSingle(
   analysisVideo: VideoMetadata,
   group: CutGroup,
   partial: string,
+  signal?: AbortSignal,
 ): Promise<ExportValidationResult> {
-  const keyframes = await probeKeyframes(analysisVideo.path, components.ffprobe);
+  const keyframes = await probeExportKeyframes(taskId, analysisVideo.path, components.ffprobe, signal);
   assertExportNotCancelled(taskId);
   const seekStart = selectSeekStart(group.start, keyframes);
   await logLine(
@@ -589,6 +613,7 @@ async function executeFastSingle(
     { targetSeconds: group.end - group.start, segmentCount: 1 },
     analysisVideo,
     'normalized',
+    signal,
   );
   await logExportTiming(taskId, 'Fast single timing', validation.timing, analysisVideo);
   return validation;
@@ -619,11 +644,14 @@ async function executeExport(
     await mkdir(tempDirectory, { recursive: true });
     const requestedBudget = assessExportDuration(duration, duration, groups.length, analysis.video);
     await logExportTiming(taskId, 'Export timing budget (fast segmented)', requestedBudget, analysis.video);
+    const signal = getTaskController(taskId)?.signal;
     const canCopy = await streamCopyEligibility(
+      taskId,
       analysis.video.path,
       groups,
       analysis.video,
       components.ffprobe,
+      signal,
     );
     assertExportNotCancelled(taskId);
     if (!canCopy && highResolution && components.mediaEncoder !== 'libx264') {
@@ -643,6 +671,8 @@ async function executeExport(
           partial,
           { targetSeconds: duration, segmentCount: 1 },
           analysis.video,
+          'preserved',
+          signal,
         );
         finalTiming = validation.timing;
         await logExportTiming(taskId, 'Stream-copy final timing', validation.timing, analysis.video);
@@ -658,6 +688,7 @@ async function executeExport(
           analysis.video,
           groups[0]!,
           partial,
+          signal,
         );
         finalTiming = validation.timing;
       }
@@ -670,6 +701,7 @@ async function executeExport(
         groups,
         partial,
         tempDirectory,
+        signal,
       );
       const encodedSegmentDuration = encodedSegmentDurations.reduce(
         (total, segmentDuration) => total + segmentDuration,
@@ -683,6 +715,7 @@ async function executeExport(
         },
         analysis.video,
         'normalized',
+        signal,
       );
       await logExportTiming(taskId, 'Fast concat timing', concatValidation.timing, analysis.video);
       const requestedTiming = assessFastConcatDuration(
@@ -702,6 +735,7 @@ async function executeExport(
         analysis.video,
         groups[0]!,
         partial,
+        signal,
       );
       finalTiming = validation.timing;
     }
@@ -724,9 +758,10 @@ async function executeExport(
       send(window, { type: 'export-result', taskId, data: result });
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    const code = exportCode(error) ?? 'EXPORT_FAILED';
     const controller = getTaskController(taskId);
+    const cancelled = controller?.cancelRequested ?? false;
+    const message = cancelled ? 'EXPORT_CANCELLED' : error instanceof Error ? error.message : String(error);
+    const code = cancelled ? 'EXPORT_CANCELLED' : exportCode(error) ?? 'EXPORT_FAILED';
     const cancelledForExit = code === 'EXPORT_CANCELLED' && controller?.cancelReason === 'app-exit';
     await logLine(taskId, cancelledForExit ? 'INFO' : 'ERROR', `${code}: ${message}`);
 

--- a/src/main/probe.ts
+++ b/src/main/probe.ts
@@ -73,20 +73,20 @@ function parseJson<T>(value: string, errorCode = 'VIDEO_UNREADABLE'): T {
   }
 }
 
-async function countFrames(ffprobe: string, videoPath: string): Promise<number | null> {
+async function countFrames(ffprobe: string, videoPath: string, signal?: AbortSignal): Promise<number | null> {
   const result = await runProcess(ffprobe, [
     '-v', 'error', '-count_frames', '-select_streams', 'v:0',
     '-show_entries', 'stream=nb_read_frames', '-of', 'json', videoPath,
-  ], { timeoutMs: 120_000 });
+  ], signal ? { signal } : {});
   const data = parseJson<{ streams?: ProbeStream[] }>(result.stdout);
   return optionalInteger(data.streams?.[0]?.nb_read_frames);
 }
 
-async function sampledVfr(ffprobe: string, videoPath: string): Promise<boolean> {
+async function sampledVfr(ffprobe: string, videoPath: string, signal?: AbortSignal): Promise<boolean> {
   const result = await runProcess(ffprobe, [
     '-v', 'error', '-select_streams', 'v:0', '-read_intervals', '%+60',
     '-show_packets', '-show_entries', 'packet=duration_time', '-of', 'json', videoPath,
-  ], { timeoutMs: 60_000 });
+  ], signal ? { timeoutMs: 60_000, signal } : { timeoutMs: 60_000 });
   const data = parseJson<{ packets?: Array<{ duration_time?: string }> }>(result.stdout);
   const durations = (data.packets ?? [])
     .map((packet) => Number(packet.duration_time))
@@ -98,14 +98,14 @@ async function sampledVfr(ffprobe: string, videoPath: string): Promise<boolean> 
   return durations.some((duration) => Math.abs(duration - median) > tolerance);
 }
 
-export async function probeVideo(videoPath: string): Promise<VideoMetadata> {
+export async function probeVideo(videoPath: string, signal?: AbortSignal): Promise<VideoMetadata> {
   const container = videoContainerFromFileName(videoPath);
   if (!container) throw new Error('INVALID_INPUT');
   const components = await resolveUsableMediaComponents();
   if (!components.ffprobe) throw new Error('MEDIA_COMPONENT_MISSING');
   const result = await runProcess(components.ffprobe, [
     '-v', 'error', '-show_format', '-show_streams', '-of', 'json', videoPath,
-  ], { timeoutMs: 30_000 });
+  ], signal ? { timeoutMs: 30_000, signal } : { timeoutMs: 30_000 });
   const data = parseJson<ProbeData>(result.stdout);
   const video = data.streams?.find((stream) => stream.codec_type === 'video');
   const audio = data.streams?.find((stream) => stream.codec_type === 'audio');
@@ -116,12 +116,13 @@ export async function probeVideo(videoPath: string): Promise<VideoMetadata> {
     throw new Error('VIDEO_UNREADABLE');
   }
   let frameCount = optionalInteger(video.nb_frames);
-  if (frameCount === null) frameCount = await countFrames(components.ffprobe, videoPath);
+  if (frameCount === null) frameCount = await countFrames(components.ffprobe, videoPath, signal);
   const fieldRatesDiffer = nominalFps > 0 && Math.abs(nominalFps - averageFps) / averageFps > 0.001;
   let packetDurationsDiffer = false;
   try {
-    packetDurationsDiffer = await sampledVfr(components.ffprobe, videoPath);
-  } catch {
+    packetDurationsDiffer = await sampledVfr(components.ffprobe, videoPath, signal);
+  } catch (error) {
+    if (signal?.aborted) throw error;
     // The rate fields remain the conservative fallback when packet sampling is unavailable.
   }
   const rotation = video.side_data_list?.find((item) => Number.isFinite(item.rotation))?.rotation
@@ -160,28 +161,39 @@ export async function probeVideo(videoPath: string): Promise<VideoMetadata> {
   });
 }
 
-export async function probeKeyframes(videoPath: string, ffprobeOverride?: string): Promise<number[]> {
+export async function probeKeyframes(
+  videoPath: string,
+  ffprobeOverride?: string,
+  signal?: AbortSignal,
+): Promise<number[]> {
   const ffprobe = ffprobeOverride ?? (await resolveUsableMediaComponents()).ffprobe;
   if (!ffprobe) throw new Error('MEDIA_COMPONENT_MISSING');
   const result = await runProcess(ffprobe, [
-    '-v', 'error', '-select_streams', 'v:0', '-skip_frame', 'nokey',
-    '-show_frames', '-show_entries', 'frame=best_effort_timestamp_time,pkt_pts_time',
+    '-v', 'error', '-select_streams', 'v:0', '-show_packets',
+    '-show_entries', 'packet=pts_time,flags',
     '-of', 'json', videoPath,
-  ], { timeoutMs: 120_000 });
-  const parsed = parseJson<{ frames?: Array<Record<string, string>> }>(result.stdout);
-  return (parsed.frames ?? [])
-    .map((frame) => Number(frame.best_effort_timestamp_time ?? frame.pkt_pts_time))
+  ], signal ? { signal } : {});
+  const parsed = parseJson<{
+    packets?: Array<{ pts_time?: string; flags?: string }>;
+  }>(result.stdout);
+  return (parsed.packets ?? [])
+    .filter((packet) => packet.flags?.includes('K'))
+    .map((packet) => Number(packet.pts_time))
     .filter((value) => Number.isFinite(value) && value >= 0)
     .sort((a, b) => a - b);
 }
 
-export async function probeAudioPacketBoundaries(videoPath: string, ffprobeOverride?: string): Promise<number[]> {
+export async function probeAudioPacketBoundaries(
+  videoPath: string,
+  ffprobeOverride?: string,
+  signal?: AbortSignal,
+): Promise<number[]> {
   const ffprobe = ffprobeOverride ?? (await resolveUsableMediaComponents()).ffprobe;
   if (!ffprobe) throw new Error('MEDIA_COMPONENT_MISSING');
   const result = await runProcess(ffprobe, [
     '-v', 'error', '-select_streams', 'a:0', '-show_packets',
     '-show_entries', 'packet=pts_time,duration_time', '-of', 'json', videoPath,
-  ], { timeoutMs: 120_000 });
+  ], signal ? { signal } : {});
   const parsed = parseJson<{
     packets?: Array<{ pts_time?: string; duration_time?: string }>;
   }>(result.stdout);
@@ -217,12 +229,16 @@ export type StreamSignature = {
   } | null;
 };
 
-export async function probeStreamSignature(videoPath: string, ffprobeOverride?: string): Promise<StreamSignature> {
+export async function probeStreamSignature(
+  videoPath: string,
+  ffprobeOverride?: string,
+  signal?: AbortSignal,
+): Promise<StreamSignature> {
   const ffprobe = ffprobeOverride ?? (await resolveUsableMediaComponents()).ffprobe;
   if (!ffprobe) throw new Error('MEDIA_COMPONENT_MISSING');
   const result = await runProcess(ffprobe, [
     '-v', 'error', '-show_streams', '-show_data_hash', 'sha256', '-of', 'json', videoPath,
-  ], { timeoutMs: 30_000 });
+  ], signal ? { timeoutMs: 30_000, signal } : { timeoutMs: 30_000 });
   const data = parseJson<ProbeData>(result.stdout);
   const video = data.streams?.find((stream) => stream.codec_type === 'video');
   const audio = data.streams?.find((stream) => stream.codec_type === 'audio');

--- a/src/main/processes.ts
+++ b/src/main/processes.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from 'node:child_process';
 
 export type ProcessResult = { stdout: string; stderr: string; code: number };
 export type TaskCancellationReason = 'user' | 'app-exit';
@@ -12,6 +12,8 @@ export type ProcessExitClassification = {
 
 export type TaskController = {
   taskId: string;
+  abortController: AbortController;
+  signal: AbortSignal;
   currentProcess: ChildProcessWithoutNullStreams | null;
   cancelRequested: boolean;
   cancelReason: TaskCancellationReason | null;
@@ -41,8 +43,11 @@ function assertTaskSlotAvailable(taskId: string): void {
 
 export function beginTrackedTask(taskId: string): TaskController {
   assertTaskSlotAvailable(taskId);
+  const abortController = new AbortController();
   const controller: TaskController = {
     taskId,
+    abortController,
+    signal: abortController.signal,
     currentProcess: null,
     cancelRequested: false,
     cancelReason: null,
@@ -86,8 +91,11 @@ export function spawnTracked(taskId: string, executable: string, args: readonly 
   let controller = controllers.get(taskId);
   if (!controller) {
     assertTaskSlotAvailable(taskId);
+    const abortController = new AbortController();
     controller = {
       taskId,
+      abortController,
+      signal: abortController.signal,
       currentProcess: null,
       cancelRequested: false,
       cancelReason: null,
@@ -166,7 +174,7 @@ export function activeTaskIds(): string[] {
   return [...new Set([...controllers.keys(), ...externalTasks.keys()])];
 }
 
-async function terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+async function terminateChild(child: ChildProcess): Promise<void> {
   child.kill('SIGTERM');
   if (process.platform === 'win32' && child.pid) {
     await new Promise<void>((resolve) => {
@@ -190,6 +198,7 @@ export async function cancelTask(taskId: string, reason: TaskCancellationReason 
   if (!controller) return;
   controller.cancelRequested = true;
   controller.cancelReason = reason;
+  if (!controller.signal.aborted) controller.abortController.abort();
   if (controller.currentProcess) await terminateChild(controller.currentProcess);
   if (!controller.explicit) {
     controllers.delete(taskId);
@@ -213,8 +222,14 @@ export function runProcess(executable: string, args: readonly string[], options:
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  signal?: AbortSignal;
 } = {}): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
+    const cancellationError = () => Object.assign(new Error('PROCESS_CANCELLED'), { name: 'AbortError' });
+    if (options.signal?.aborted) {
+      reject(cancellationError());
+      return;
+    }
     const child = spawn(executable, [...args], {
       cwd: options.cwd,
       env: options.env,
@@ -229,10 +244,22 @@ export function runProcess(executable: string, args: readonly string[], options:
     child.stdout.on('data', (chunk: string) => { stdout += chunk; });
     child.stderr.on('data', (chunk: string) => { stderr += chunk; });
     const timer = options.timeoutMs ? setTimeout(() => child.kill(), options.timeoutMs) : null;
-    child.once('error', reject);
-    child.once('close', (code, signal) => {
+    const abort = () => { void terminateChild(child); };
+    const cleanup = () => {
       if (timer) clearTimeout(timer);
-      if (code === 0) {
+      options.signal?.removeEventListener('abort', abort);
+    };
+    options.signal?.addEventListener('abort', abort, { once: true });
+    if (options.signal?.aborted) abort();
+    child.once('error', (error) => {
+      cleanup();
+      reject(options.signal?.aborted ? cancellationError() : error);
+    });
+    child.once('close', (code, signal) => {
+      cleanup();
+      if (options.signal?.aborted) {
+        reject(cancellationError());
+      } else if (code === 0) {
         resolve({ stdout, stderr, code });
       } else if (code === null || signal !== null) {
         reject(new Error(stderr.trim() || `Process terminated by signal ${String(signal)}`));

--- a/tests/e2e/real-workflow.spec.ts
+++ b/tests/e2e/real-workflow.spec.ts
@@ -445,7 +445,7 @@ test('real CUDA analysis, single-rally export, and final preview', async ({}, te
     await expect(page.getByRole('button', { name: '开始剪辑' })).toBeEnabled();
     await page.getByRole('button', { name: '开始剪辑' }).click();
     await expect(page.getByRole('heading', { name: /正在/ })).toBeVisible();
-    await expect(page.getByRole('heading', { name: '成功导出' })).toBeVisible({ timeout: 2 * 60 * 1_000 });
+    await expect(page.getByRole('heading', { name: '成功导出' })).toBeVisible({ timeout: 0 });
 
     const outputDetails = page.locator('.output-details strong');
     const outputPath = (await outputDetails.nth(1).textContent())?.trim();
@@ -566,9 +566,9 @@ test('automatic calibration completes serial multi-task analysis and records zer
     const rows = page.locator('.batch-row');
     await expect(rows.nth(0).locator('.batch-cover.processing')).toBeVisible({ timeout: 30_000 });
     await expect(page.locator('.batch-cover.processing')).toHaveCount(1);
-    await expect(rows.nth(1).locator('.batch-cover.processing')).toBeVisible({ timeout: 2 * 60 * 1_000 });
+    await expect(rows.nth(1).locator('.batch-cover.processing')).toBeVisible({ timeout: 0 });
     await expect(page.locator('.batch-cover.processing')).toHaveCount(1);
-    await expect(page.locator('.batch-start')).toBeEnabled({ timeout: 2 * 60 * 1_000 });
+    await expect(page.locator('.batch-start')).toBeEnabled({ timeout: 0 });
     await rows.nth(0).locator('.batch-cover').click();
     const preview = page.locator('.batch-preview');
     await expect(preview).toBeVisible();
@@ -699,7 +699,7 @@ test('failed batch calibration can be repaired manually and returned to the runn
 
     await page.locator('.drop-zone').click();
     await expect(page.locator('.multi-task-page')).toBeVisible({ timeout: 30_000 });
-    await expect(page.getByText('标定失败')).toBeVisible({ timeout: 2 * 60 * 1_000 });
+    await expect(page.getByText('标定失败')).toBeVisible({ timeout: 0 });
     await expect(page.getByText('手动标定')).toBeVisible();
     await expect(page.getByText('AUTO_CALIBRATION_FAILED')).toHaveCount(0);
     const failedCoverVideoStyle = await page.getByRole('button', { name: 'calibration-failure.mp4 手动标定' })
@@ -718,7 +718,7 @@ test('failed batch calibration can be repaired manually and returned to the runn
     await expect(finishCalibration).toBeEnabled();
     await finishCalibration.click();
     await expect(page.getByRole('heading', { name: '多任务剪辑' })).toBeVisible();
-    await expect(page.locator('.batch-start')).toBeEnabled({ timeout: 2 * 60 * 1_000 });
+    await expect(page.locator('.batch-start')).toBeEnabled({ timeout: 0 });
 
     for (const row of await page.locator('.batch-row').all()) {
       await row.locator('.batch-mode-options button').nth(2).click();

--- a/tests/export-start.test.ts
+++ b/tests/export-start.test.ts
@@ -10,7 +10,15 @@ const state = vi.hoisted(() => {
   return {
     source: '',
     events: [] as AppEvent[],
-    keyframes: vi.fn(() => new Promise<number[]>((resolve) => { releaseKeyframes = resolve; })),
+    keyframes: vi.fn((_path: string, _ffprobe: string, signal?: AbortSignal) => new Promise<number[]>((resolve, reject) => {
+      const abort = () => reject(Object.assign(new Error('PROCESS_CANCELLED'), { name: 'AbortError' }));
+      releaseKeyframes = (value) => {
+        signal?.removeEventListener('abort', abort);
+        resolve(value);
+      };
+      signal?.addEventListener('abort', abort, { once: true });
+      if (signal?.aborted) abort();
+    })),
     release: (value: number[]) => releaseKeyframes?.(value),
   };
 });
@@ -128,7 +136,6 @@ describe('export task start and terminal lifecycle', () => {
     await vi.waitFor(() => expect(state.keyframes).toHaveBeenCalledTimes(1));
 
     await cancelTask(taskId, 'user');
-    state.release([]);
     await waitForTaskEnd(taskId);
     const terminal = state.events.filter((event) => event.type === 'error' || event.type === 'export-result');
     expect(terminal).toEqual([
@@ -140,7 +147,6 @@ describe('export task start and terminal lifecycle', () => {
     const taskId = await startExport(windowMock() as never, request);
     await vi.waitFor(() => expect(state.keyframes).toHaveBeenCalledTimes(1));
     await cancelTask(taskId, 'app-exit');
-    state.release([]);
     await waitForTaskEnd(taskId);
     expect(state.events.filter((event) => event.type === 'error')).toEqual([]);
   });

--- a/tests/fast-segmented-export.integration.test.ts
+++ b/tests/fast-segmented-export.integration.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -13,6 +13,7 @@ import {
   expectedOutputDuration,
   selectSeekStart,
 } from '../src/main/media-plan';
+import { probeKeyframes } from '../src/main/probe';
 import { assessExportDuration } from '../src/domain/export-duration';
 
 const input = process.env.TTCUT_VIDEO_INTEGRATION;
@@ -54,10 +55,12 @@ const concatEqualDtsRegressionGroups: CutGroup[] = [
   { rallyIds: ['rally_002'], rawStart: 17.234, rawEnd: 21.464, start: 14.734, end: 24.464 },
 ];
 
-function run(executable: string, args: string[], timeout = 120_000): string {
-  const result = spawnSync(executable, args, {
-    encoding: 'utf8', windowsHide: true, shell: false, timeout,
-  });
+function run(executable: string, args: string[], timeout?: number): string {
+  const options: SpawnSyncOptionsWithStringEncoding = {
+    encoding: 'utf8', windowsHide: true, shell: false,
+    ...(timeout === undefined ? {} : { timeout }),
+  };
+  const result = spawnSync(executable, args, options);
   if (result.status !== 0) throw new Error(result.stderr || `Process exited with ${result.status}`);
   return result.stdout;
 }
@@ -65,11 +68,13 @@ function run(executable: string, args: string[], timeout = 120_000): string {
 function runWithStderr(
   executable: string,
   args: string[],
-  timeout = 120_000,
+  timeout?: number,
 ): { stdout: string; stderr: string } {
-  const result = spawnSync(executable, args, {
-    encoding: 'utf8', windowsHide: true, shell: false, timeout,
-  });
+  const options: SpawnSyncOptionsWithStringEncoding = {
+    encoding: 'utf8', windowsHide: true, shell: false,
+    ...(timeout === undefined ? {} : { timeout }),
+  };
+  const result = spawnSync(executable, args, options);
   if (result.status !== 0) throw new Error(result.stderr || `Process exited with ${result.status}`);
   return { stdout: result.stdout, stderr: result.stderr };
 }
@@ -535,6 +540,34 @@ describe.each(cases)('fast segmented export with $encoder', ({ encoder, ffmpeg, 
 });
 
 describe.skipIf(!syntheticEnabled)('fast segmented timestamp repair with generated media', () => {
+  it('matches decoder keyframes with packet-level probing for H.264 B-frame media', async () => {
+    if (!syntheticFfmpeg || !syntheticFfprobe) throw new Error('Integration environment is incomplete.');
+    const directory = mkdtempSync(path.join(tmpdir(), 'ttcut-keyframe-probe-'));
+    try {
+      const source = path.join(directory, 'source.mp4');
+      run(syntheticFfmpeg, [
+        '-hide_banner', '-y',
+        '-f', 'lavfi', '-i', 'testsrc2=size=320x240:rate=60:duration=6',
+        '-c:v', 'libx264', '-preset', 'medium', '-g', '60', '-bf', '2', '-an', source,
+      ]);
+
+      const packetKeyframes = await probeKeyframes(source, syntheticFfprobe);
+      const frameData = JSON.parse(run(syntheticFfprobe, [
+        '-v', 'error', '-select_streams', 'v:0', '-skip_frame', 'nokey',
+        '-show_frames', '-show_entries', 'frame=best_effort_timestamp_time,pkt_pts_time',
+        '-of', 'json', source,
+      ])) as { frames?: Array<{ best_effort_timestamp_time?: string; pkt_pts_time?: string }> };
+      const decodedKeyframes = (frameData.frames ?? [])
+        .map((frame) => Number(frame.best_effort_timestamp_time ?? frame.pkt_pts_time))
+        .filter((value) => Number.isFinite(value) && value >= 0)
+        .sort((left, right) => left - right);
+
+      expect(packetKeyframes).toEqual(decodedKeyframes);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }, 180_000);
+
   it('joins separately encoded 44.1 kHz AAC segments without DTS regressions', () => {
     if (!syntheticFfmpeg || !syntheticFfprobe) throw new Error('Integration environment is incomplete.');
     const directory = mkdtempSync(path.join(tmpdir(), 'ttcut-aac-timestamps-'));

--- a/tests/media-export.integration.test.ts
+++ b/tests/media-export.integration.test.ts
@@ -69,7 +69,6 @@ describe.skipIf(!enabled)('real FFmpeg export', () => {
       encoding: 'utf8',
       windowsHide: true,
       shell: false,
-      timeout: 120_000,
     });
     if (encode.status !== 0) throw new Error(encode.stderr || `FFmpeg exited with ${encode.status}`);
     expect(existsSync(output)).toBe(true);
@@ -110,7 +109,7 @@ describe.skipIf(!enabled)('real FFmpeg export', () => {
     const quality = spawnSync(ffmpeg, [
       '-hide_banner', '-i', input, '-i', output,
       '-filter_complex', filters.join(';'), '-an', '-f', 'null', 'NUL',
-    ], { encoding: 'utf8', windowsHide: true, shell: false, timeout: 120_000 });
+    ], { encoding: 'utf8', windowsHide: true, shell: false });
     if (quality.status !== 0) throw new Error(quality.stderr || `SSIM check exited with ${quality.status}`);
     const match = /All:([0-9.]+)/.exec(quality.stderr);
     expect(match, quality.stderr).not.toBeNull();

--- a/tests/probe.test.ts
+++ b/tests/probe.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  runProcess: vi.fn(),
+}));
+
+vi.mock('../src/main/processes', () => ({
+  runProcess: state.runProcess,
+}));
+
+vi.mock('../src/main/components', () => ({
+  resolveUsableMediaComponents: vi.fn(),
+}));
+
+import { probeKeyframes } from '../src/main/probe';
+
+describe('keyframe probing', () => {
+  beforeEach(() => {
+    state.runProcess.mockReset();
+  });
+
+  it('returns sorted keyframe packet timestamps without a fixed timeout', async () => {
+    state.runProcess.mockResolvedValue({
+      stdout: JSON.stringify({
+        packets: [
+          { pts_time: '4.250000', flags: 'K__' },
+          { pts_time: '1.500000', flags: '___' },
+          { pts_time: '0.000000', flags: 'K__' },
+          { pts_time: '-0.250000', flags: 'K__' },
+          { pts_time: 'invalid', flags: 'K__' },
+          { pts_time: '2.125000', flags: '__K' },
+        ],
+      }),
+      stderr: '',
+      code: 0,
+    });
+
+    await expect(probeKeyframes('source.mp4', 'ffprobe.exe')).resolves.toEqual([
+      0,
+      2.125,
+      4.25,
+    ]);
+    expect(state.runProcess).toHaveBeenCalledWith('ffprobe.exe', [
+      '-v', 'error', '-select_streams', 'v:0', '-show_packets',
+      '-show_entries', 'packet=pts_time,flags', '-of', 'json', 'source.mp4',
+    ], {});
+  });
+});

--- a/tests/processes.test.ts
+++ b/tests/processes.test.ts
@@ -8,12 +8,13 @@ import {
   endTrackedTask,
   getTaskController,
   markTaskTerminal,
+  runProcess,
   spawnTracked,
 } from '../src/main/processes';
 
 afterEach(async () => {
   await cancelAllTasks('app-exit');
-  for (const taskId of ['normal', 'gap', 'cancelled']) endTrackedTask(taskId);
+  for (const taskId of ['normal', 'gap', 'cancelled', 'signal']) endTrackedTask(taskId);
 });
 
 describe('tracked task lifecycle', () => {
@@ -60,5 +61,31 @@ describe('tracked task lifecycle', () => {
     expect(markTaskTerminal('cancelled')).toBe(true);
     expect(markTaskTerminal('cancelled')).toBe(false);
     expect(getTaskController('cancelled')?.terminal).toBe(true);
+  });
+
+  it('cancels a process without requiring a timeout', async () => {
+    const controller = new AbortController();
+    const result = runProcess(process.execPath, [
+      '-e',
+      'setTimeout(() => process.exit(0), 1500); setInterval(() => {}, 1000);',
+    ], { signal: controller.signal });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'PROCESS_CANCELLED',
+    });
+  });
+
+  it('aborts the signal exposed by a tracked task when cancelled', async () => {
+    beginTrackedTask('signal');
+    const signal = getTaskController('signal')?.signal;
+    expect(signal?.aborted).toBe(false);
+
+    await cancelTask('signal', 'user');
+
+    expect(signal?.aborted).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- replace full-video decoded-frame keyframe discovery with packet-level FFprobe keyframe discovery
- remove all project-wide 120-second process and test timeouts without introducing replacement deadlines
- propagate explicit cancellation signals through export probes and component setup subprocesses
- add probe, cancellation, and H.264 B-frame regression coverage

## Root cause

CPU-only exports scanned every decoded video frame before segmented encoding. The fixed 120-second FFprobe timeout terminated long scans with SIGTERM, so a roughly 31-minute, 68-segment export failed before the first segment was encoded.

## Impact

Long CPU-only exports no longer fail at two minutes during keyframe discovery. User cancellation and application shutdown still terminate the active FFprobe/FFmpeg process tree and report the correct terminal state.

## Validation

- `npm run typecheck`
- `npx vitest run` — 191 passed, 17 environment-dependent tests skipped
- H.264 B-frame packet/frame keyframe equivalence integration test
- `node --check scripts/build-analysis-runtime.mjs`
- static scan confirms no remaining 120-second timeout configuration