### PR TITLE
Fix TASK_BUSY race between multi-task exports and analysis

### DIFF
--- a/src/main/export.ts
+++ b/src/main/export.ts
@@ -633,12 +633,11 @@ async function executeExport(
   const analysis = record.analysis;
   const highResolution = analysis.video.width > 4096 || analysis.video.height > 2160;
   const tempDirectory = path.join(path.dirname(output), `.ttcut-${taskId}-segments`);
-  let terminalSent = false;
+  let terminalEvent: Extract<AppEvent, { type: 'export-result' | 'error' }> | null = null;
   let finalTiming: ExportTimingAssessment | null = null;
   const sendError = async (code: string, message: string): Promise<void> => {
-    if (terminalSent || !markTaskTerminal(taskId)) return;
-    terminalSent = true;
-    send(window, { type: 'error', taskId, code, message });
+    if (terminalEvent || !markTaskTerminal(taskId)) return;
+    terminalEvent = { type: 'error', taskId, code, message };
   };
   try {
     await mkdir(tempDirectory, { recursive: true });
@@ -753,9 +752,8 @@ async function executeExport(
     send(window, { type: 'progress', data: { taskId, kind: 'export', stage: 'complete', percent: 100 } });
     lastExportProgress.set(taskId, 100);
     await getHistoryStore().markVisible(record.id, 'export', output);
-    if (!terminalSent && markTaskTerminal(taskId)) {
-      terminalSent = true;
-      send(window, { type: 'export-result', taskId, data: result });
+    if (!terminalEvent && markTaskTerminal(taskId)) {
+      terminalEvent = { type: 'export-result', taskId, data: result };
     }
   } catch (error) {
     const controller = getTaskController(taskId);
@@ -804,9 +802,8 @@ async function executeExport(
           };
           send(window, { type: 'progress', data: { taskId, kind: 'export', stage: 'complete', percent: 100 } });
           lastExportProgress.set(taskId, 100);
-          if (!terminalSent && markTaskTerminal(taskId)) {
-            terminalSent = true;
-            send(window, { type: 'export-result', taskId, data: result });
+          if (!terminalEvent && markTaskTerminal(taskId)) {
+            terminalEvent = { type: 'export-result', taskId, data: result };
           }
           return;
         }
@@ -825,6 +822,7 @@ async function executeExport(
     await rm(tempDirectory, { recursive: true, force: true }).catch(() => undefined);
     lastExportProgress.delete(taskId);
     endTrackedTask(taskId);
+    if (terminalEvent) send(window, terminalEvent);
   }
 }
 

--- a/tests/export-start.test.ts
+++ b/tests/export-start.test.ts
@@ -10,6 +10,7 @@ const state = vi.hoisted(() => {
   return {
     source: '',
     events: [] as AppEvent[],
+    terminalTaskActive: [] as boolean[],
     keyframes: vi.fn((_path: string, _ffprobe: string, signal?: AbortSignal) => new Promise<number[]>((resolve, reject) => {
       const abort = () => reject(Object.assign(new Error('PROCESS_CANCELLED'), { name: 'AbortError' }));
       releaseKeyframes = (value) => {
@@ -100,7 +101,12 @@ function windowMock() {
   return {
     isDestroyed: () => false,
     webContents: {
-      send: (_channel: string, event: AppEvent) => state.events.push(event),
+      send: (_channel: string, event: AppEvent) => {
+        state.events.push(event);
+        if (event.type === 'error' || event.type === 'export-result') {
+          state.terminalTaskActive.push(Boolean(getTaskController(event.taskId)));
+        }
+      },
     },
   };
 }
@@ -119,6 +125,7 @@ describe('export task start and terminal lifecycle', () => {
     directory = await mkdtemp(path.join(tmpdir(), 'ttcut-export-start-'));
     state.source = path.join(directory, 'source.mp4');
     state.events.length = 0;
+    state.terminalTaskActive.length = 0;
     state.keyframes.mockClear();
     await writeFile(state.source, 'source');
   });
@@ -141,6 +148,7 @@ describe('export task start and terminal lifecycle', () => {
     expect(terminal).toEqual([
       expect.objectContaining({ type: 'error', taskId, code: 'EXPORT_CANCELLED' }),
     ]);
+    expect(state.terminalTaskActive).toEqual([false]);
   });
 
   it('records app-exit cancellation without sending an error terminal event', async () => {


### PR DESCRIPTION
## What changed

- Defer export terminal events until export cleanup and task-slot release complete.
- Add a regression assertion that no task controller remains when a terminal event reaches the renderer.

## Why

The multi-task queue starts the next analysis as soon as it receives the previous export terminal event. Previously `export-result` and export errors were sent before `endTrackedTask`, so the next `analysis:start` could observe the previous export and fail with `TASK_BUSY`.

## Validation

- `npm run typecheck`
- `npm test -- --run tests/export-start.test.ts tests/multi-task-page.test.tsx tests/processes.test.ts`

Target: `develop`