### PR TITLE
恢复完成后关机并新增多任务合并剪辑

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,5 +1,20 @@
 # TTcut Context
 
+## Merged Highlight Video
+
+A single video containing the selected clips from the participating videos in
+a batch, ordered by when each source was added and then by source time. It is
+the batch's shared output, not an individual source video's highlight export.
+_UI_: 合并集锦, 合并为一个视频
+
+## Participating Video
+
+A video currently set to All Rallies or Highlights in a merged batch. Each
+participating video uses its own selection conditions; Analyze Only videos
+do not contribute clips. A successful analysis with no matching clips is an
+empty selection, not a failed video.
+_UI_: 参与剪辑的视频
+
 ## Analysis Model
 
 An immutable checkpoint bundled with the application and verified by filename,

--- a/docs/testing-batch-export.md
+++ b/docs/testing-batch-export.md
@@ -1,0 +1,32 @@
+# 多任务合并导出验证
+
+常规回归运行 `npm.cmd run typecheck` 和 `npm.cmd test`。合并相关用例覆盖
+动态修改、添加文件等待、任务取消和重试、空片段、历史记录保留及完成后关机。
+
+真实媒体测试需要将 `TTCUT_FFMPEG_INTEGRATION` 和 `TTCUT_FFPROBE_INTEGRATION`
+设为对应可执行文件的绝对路径，并设置 `TTCUT_BATCH_ENCODER` 为该组件支持的
+`libopenh264` 或 `libx264`。运行：
+
+```text
+npm.cmd test -- tests/batch-export.integration.test.ts
+```
+
+该测试生成混合尺寸、横竖屏、旋转、分数帧率、VFR 和有无音轨的素材，真实执行
+合并导出，检查顺序、画面尺寸、黑边、时长和音画同步。将 `TTCUT_BATCH_TEST_ROOT`
+设为一个已存在的输出目录（建议 `output/batch-export-validation`）可保留素材、
+成片和 `validation.json`；未设置时使用临时目录并在测试后清理。
+
+真实 Electron 检查先按上述路径保留成功的媒体测试产物，再运行：
+
+```text
+npm.cmd run package
+node scripts/verify-batch-ui.cjs
+```
+
+界面检查沿用仓库的 `.baseline/electron-dev/43.1.1` Electron 和
+`.baseline/components/ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-shared-8.1/bin`
+媒体组件，加载本次打包生成的生产页面资源。使用独立用户目录和预置分析结果，
+真实执行合并 IPC、历史读取、FFmpeg 和媒体预览。操作系统关机由测试拦截。
+截图、成片、调用次数与 `evidence.json` 保存在 `output/playwright/batch-merge-*`。
+
+预置分析结果只用于界面和导出回归，不构成球检测模型或真实比赛分析效果的验证。

--- a/scripts/verify-batch-ui.cjs
+++ b/scripts/verify-batch-ui.cjs
@@ -1,0 +1,149 @@
+const { _electron } = require('playwright');
+const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+(async () => {
+  const project = process.cwd();
+  const output = path.join(project, 'output', 'playwright', `batch-merge-${Date.now()}`);
+  await fs.mkdir(output, { recursive: true });
+  const userData = path.join(output, 'user-data');
+  await fs.mkdir(path.join(userData, 'history', 'records'), { recursive: true });
+  const validationRoot = path.join(project, 'output', 'batch-export-validation');
+  const fixtureDirectories = await fs.readdir(validationRoot);
+  let fixture;
+  for (const directory of fixtureDirectories) {
+    if (await fs.stat(path.join(validationRoot, directory, 'validation.json')).catch(() => null)) fixture = path.join(validationRoot, directory);
+  }
+  assert(fixture, 'Run the real merged-media integration check first');
+  const files = ['red.mp4', 'green.mp4'].map((name) => path.join(output, name));
+  await Promise.all(files.map((file) => fs.copyFile(path.join(fixture, path.basename(file)), file)));
+  const ffmpegRoot = path.join(project, '.baseline', 'components', 'ffmpeg-n8.1.2-22-g94138f6973-win64-lgpl-shared-8.1', 'bin');
+  const electron = await _electron.launch({
+    executablePath: path.join(project, '.baseline', 'electron-dev', '43.1.1', 'electron.exe'),
+    args: ['--no-sandbox', '--disable-gpu', project],
+    env: { ...process.env, TTCUT_E2E: '1', TTCUT_E2E_USER_DATA: userData,
+      TTCUT_E2E_COMPONENTS_ROOT: path.join(output, 'components'), TTCUT_E2E_VIDEOS: JSON.stringify(files),
+      TTCUT_E2E_REVEAL_MARKER: path.join(output, 'revealed.txt'),
+      TTCUT_FFMPEG: path.join(ffmpegRoot, 'ffmpeg.exe'), TTCUT_FFPROBE: path.join(ffmpegRoot, 'ffprobe.exe') },
+  });
+  let page;
+  try {
+    page = await electron.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.waitForFunction(() => Boolean(window.ttcut));
+    const bootstrap = await page.evaluate(() => window.ttcut.bootstrap());
+    const metadata = await page.evaluate((paths) => Promise.all(paths.map((file) => window.ttcut.probeVideo(file))), files);
+    const records = await Promise.all(metadata.map(async (video) => {
+      const info = await fs.stat(video.path);
+      const calibration = { video_width: video.width, video_height: video.height, points: {
+        top_left: [video.width * .3, video.height * .2], top_right: [video.width * .7, video.height * .2],
+        bottom_right: [video.width * .8, video.height * .8], bottom_left: [video.width * .2, video.height * .8],
+      } };
+      const record = { schema_version: 1, id: crypto.randomUUID(), analyzed_at: new Date().toISOString(),
+        source: { path: video.path, name: path.basename(video.path), size: info.size, modified_time_ms: info.mtimeMs },
+        calibration, analysis: { schema_version: 1, video,
+          rallies: [{ id: 'rally_001', index: 1, bounce_count: 5, start_time_seconds: 2, end_time_seconds: 2.2 }] },
+        visible_in_history: true, completion_kind: 'analysis', output_path: null };
+      await fs.writeFile(path.join(userData, 'history', 'records', `${record.id}.json`), JSON.stringify(record));
+      return record;
+    }));
+    // Only calibration/analysis are fixtures. The production batch-export IPC, history reads,
+    // FFmpeg, media protocol and renderer all run unchanged. OS shutdown is always intercepted.
+    await electron.evaluate(({ ipcMain, BrowserWindow }, { bootstrap, records }) => {
+      const state = { shutdowns: 0, analyses: 0, events: [] };
+      globalThis.__batchUiCheck = state;
+      ipcMain.removeHandler('app:bootstrap');
+      ipcMain.handle('app:bootstrap', () => ({ ...bootstrap, components: { ...bootstrap.components,
+        analysis: { ...bootstrap.components.analysis, available: true }, media: { ...bootstrap.components.media, available: true } } }));
+      ipcMain.removeHandler('system:shutdown');
+      ipcMain.handle('system:shutdown', () => { state.shutdowns += 1; });
+      ipcMain.removeHandler('calibration:start');
+      ipcMain.handle('calibration:start', (_event, input) => {
+        const record = records.find((record) => record.source.path === input.videoPath);
+        const taskId = `calibration-${record.id}`;
+        setTimeout(() => BrowserWindow.getAllWindows()[0].webContents.send('task:event', {
+          type: 'calibration-result', taskId, calibration: record.calibration, tableAnalysis: {},
+        }), 250);
+        return taskId;
+      });
+      ipcMain.removeHandler('analysis:start');
+      ipcMain.handle('analysis:start', (_event, input) => {
+        state.analyses += 1;
+        const record = records.find((record) => record.source.path === input.videoPath);
+        const taskId = `analysis-${record.id}`;
+        setTimeout(() => BrowserWindow.getAllWindows()[0].webContents.send('task:event', {
+          type: 'analysis-result', taskId, analysisId: record.id, calibration: record.calibration, data: record.analysis,
+        }), 1500);
+        return taskId;
+      });
+    }, { bootstrap, records });
+    await page.evaluate(() => localStorage.setItem('ttcut.supportPrompt.snoozedUntil', String(Date.now() + 86400000)));
+    await page.reload();
+    await page.getByRole('button', { name: '选择或将文件拖到这里' }).click();
+    await page.locator('.multi-task-page .batch-start:not(:disabled)').waitFor();
+    const launcher = page.locator('.batch-launcher');
+    const options = page.locator('.batch-launch-options');
+    const setOption = async (name, checked) => {
+      const input = page.getByRole('checkbox', { name });
+      if (await input.isChecked() !== checked) await input.locator('..').click();
+      assert.equal(await input.isChecked(), checked);
+    };
+    await page.mouse.move(5, 5);
+    assert.equal(await options.evaluate((node) => getComputedStyle(node).visibility), 'hidden');
+    await launcher.hover();
+    await page.waitForFunction(() => getComputedStyle(document.querySelector('.batch-launch-options')).opacity === '1');
+    assert.equal(await page.locator('.batch-launcher .custom-export-options').count(), 1);
+    assert.equal(await options.locator('.export-checkbox').count(), 2);
+    assert.equal(await options.evaluate((node) => getComputedStyle(node).borderRadius), '12px');
+    assert.equal(await options.locator('.export-checkbox-control').first().evaluate((node) => getComputedStyle(node).width), '16px');
+    await setOption('合并为一个视频', true);
+    await setOption('完成本任务后关机', true);
+    await page.screenshot({ path: path.join(output, 'options.png'), fullPage: true });
+    await page.getByRole('button', { name: '开始分析剪辑' }).click();
+    assert.equal(await page.getByRole('checkbox', { name: '合并为一个视频' }).isDisabled(), true);
+    await launcher.hover();
+    await setOption('完成本任务后关机', false);
+    await setOption('完成本任务后关机', true);
+    assert.equal(await electron.evaluate(() => globalThis.__batchUiCheck.shutdowns), 0);
+    await page.getByText('合并视频已完成', { exact: true }).waitFor({ timeout: 60000 });
+    assert.equal(await electron.evaluate(() => globalThis.__batchUiCheck.shutdowns), 1);
+    const exported = await page.locator('.batch-merged-path').innerText();
+    assert((await fs.stat(exported)).size > 1024);
+    await page.getByRole('button', { name: '预览输出', exact: true }).click();
+    await page.waitForFunction(() => document.querySelector('.batch-preview video')?.readyState >= 2);
+    const playback = await page.locator('.batch-preview video').evaluate((video) => ({
+      width: video.videoWidth, height: video.videoHeight, duration: video.duration, error: video.error,
+    }));
+    assert.equal(playback.width, 320);
+    assert.equal(playback.height, 180);
+    assert.equal(playback.error, null);
+    await page.screenshot({ path: path.join(output, 'preview.png'), fullPage: true });
+    await page.locator('.batch-preview-header button').click();
+    await page.getByRole('button', { name: '打开文件夹', exact: true }).click();
+    assert.equal(await fs.readFile(path.join(output, 'revealed.txt'), 'utf8'), exported);
+    await launcher.focus();
+    await page.waitForFunction(() => getComputedStyle(document.querySelector('.batch-launch-options')).opacity === '1');
+    for (const group of await page.getByRole('group').all()) await group.getByRole('button', { name: '只分析' }).click();
+    await launcher.focus();
+    const mergedCheckbox = page.getByRole('checkbox', { name: '合并为一个视频' });
+    assert.equal(await mergedCheckbox.isDisabled(), true);
+    assert.equal(await mergedCheckbox.isChecked(), false);
+    assert.deepEqual(errors, []);
+    const evidence = { page: page.url(), exported, playback, state: await electron.evaluate(() => globalThis.__batchUiCheck), errors,
+      analysis: 'seeded fixtures; real batch-export IPC/FFmpeg/media playback', screenshots: ['options.png', 'preview.png'] };
+    await fs.writeFile(path.join(output, 'evidence.json'), JSON.stringify(evidence, null, 2));
+    console.log(JSON.stringify({ success: true, output, ...evidence }, null, 2));
+  } catch (error) {
+    if (page) {
+      await page.screenshot({ path: path.join(output, 'failure.png'), fullPage: true }).catch(() => {});
+      console.error(await page.locator('body').innerText().catch(() => 'No body'));
+    }
+    throw error;
+  } finally {
+    await electron.close();
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/src/main/batch-export.ts
+++ b/src/main/batch-export.ts
@@ -1,0 +1,145 @@
+import { constants } from 'node:fs';
+import { copyFile, link, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { BrowserWindow } from 'electron';
+import { batchExportRequestSchema, type BatchExportRequest, type CutGroup, type VideoMetadata } from '../shared/contracts';
+import type { AppEvent } from '../shared/api';
+import { IPC } from '../shared/ipc';
+import { createCutGroups, SelectionError } from '../domain/segments';
+import { getHistoryStore } from './history';
+import { resolveUsableMediaComponents } from './components';
+import { batchOutputProfile, batchSegmentDuration, buildBatchSegmentArgs } from './batch-media-plan';
+import { buildConcatArgs, buildConcatManifest } from './media-plan';
+import { assertExportPreconditions, clearExportProgress, runFfmpeg, uniqueOutput, validateExportOutput } from './export';
+import { beginTrackedTask, endTrackedTask, markTaskTerminal } from './processes';
+import { registerMediaPath } from './media-protocol';
+import { logLine } from './logger';
+
+function send(window: BrowserWindow, event: AppEvent): void {
+  if (!window.isDestroyed()) window.webContents.send(IPC.taskEvent, event);
+}
+
+async function executeBatchExport(window: BrowserWindow, taskId: string, request: BatchExportRequest, signal: AbortSignal) {
+  let temporaryDirectory: string | null = null;
+  let terminal: AppEvent = { type: 'error', taskId, code: 'EXPORT_FAILED', message: 'Batch export did not complete' };
+  try {
+    const records = await Promise.all(request.items.map((item) => getHistoryStore().open(item.analysis_id)));
+    signal.throwIfAborted();
+    // Cached analyses from an earlier failed individual export may still be deferred.
+    // Retain them as analysis history, without attaching the batch video to each source.
+    await Promise.all(records.filter((record) => record.visible_in_history === false)
+      .map((record) => getHistoryStore().markVisible(record.id, 'analysis')));
+    const skippedAnalysisIds: string[] = [];
+    const segments: Array<{ video: VideoMetadata; group: CutGroup }> = [];
+    records.forEach((record, index) => {
+      let groups: CutGroup[];
+      try {
+        groups = [...createCutGroups(record.analysis, request.items[index]!.selection)]
+          .sort((left, right) => left.start - right.start);
+      } catch (error) {
+        if (!(error instanceof SelectionError) || !['NO_RALLIES', 'NO_HIGHLIGHTS'].includes(error.code)) throw error;
+        groups = [];
+      }
+      if (!groups.length) skippedAnalysisIds.push(record.id);
+      for (const group of groups) segments.push({ video: record.analysis.video, group });
+    });
+    if (!segments.length) throw new Error('BATCH_EXPORT_EMPTY');
+    const components = await resolveUsableMediaComponents();
+    if (!components.ffmpeg || !components.ffprobe || components.mediaEncoder === 'unavailable') {
+      throw new Error('MEDIA_COMPONENT_MISSING');
+    }
+    const first = records[0]!;
+    const source = first.analysis.source_video?.path ?? first.source.path;
+    const profile = batchOutputProfile(first.analysis.video, segments.some((segment) => segment.video.audio_codec !== null));
+    const requestedDuration = segments.reduce((sum, segment) => sum + segment.group.end - segment.group.start, 0);
+    const durations = segments.map((segment) => batchSegmentDuration(segment.group, profile));
+    const duration = durations.reduce((sum, value) => sum + value, 0);
+    await assertExportPreconditions(first.analysis.video.path, path.dirname(source), taskId, duration, profile, components.mediaEncoder);
+    signal.throwIfAborted();
+    temporaryDirectory = await mkdtemp(path.join(path.dirname(source), `.ttcut-batch-${taskId}-`));
+    const names: string[] = [];
+    let elapsed = 0;
+    for (const [index, segment] of segments.entries()) {
+      signal.throwIfAborted();
+      const name = `segment-${String(index).padStart(6, '0')}.mp4`;
+      const segmentPath = path.join(temporaryDirectory, name);
+      names.push(name);
+      await runFfmpeg(window, taskId, components.ffmpeg,
+        buildBatchSegmentArgs(segment.video, profile, segment.group, segmentPath, components.mediaEncoder),
+        durations[index]!, 'cutting-and-exporting', { segmentIndex: index + 1 }, {
+          startPercent: elapsed / duration * 85,
+          endPercent: (elapsed + durations[index]!) / duration * 85,
+        });
+      await validateExportOutput(segmentPath, { targetSeconds: durations[index]!, segmentCount: 1 }, profile, 'normalized', signal);
+      elapsed += durations[index]!;
+    }
+    const manifest = path.join(temporaryDirectory, 'segments.ffconcat');
+    await writeFile(manifest, buildConcatManifest(names, durations), 'utf8');
+    const partial = path.join(temporaryDirectory, 'combined.mp4');
+    await runFfmpeg(window, taskId, components.ffmpeg, buildConcatArgs(manifest, partial, profile), duration,
+      'concatenating', undefined, { startPercent: 85, endPercent: 95 });
+    const validation = await validateExportOutput(partial, { targetSeconds: duration, segmentCount: 1 }, profile, 'normalized', signal);
+    await validateExportOutput(partial, { targetSeconds: requestedDuration, segmentCount: segments.length }, profile, 'normalized', signal);
+    if (Math.abs(validation.metadata.fps - profile.fps) > profile.fps * 0.001) throw new Error('EXPORT_FRAME_RATE_MISMATCH');
+    // Decode the entire output, not just its header or first frame, before publishing success.
+    await runFfmpeg(window, taskId, components.ffmpeg,
+      ['-hide_banner', '-v', 'error', '-xerror', '-i', partial, '-map', '0:v:0', '-map', '0:a?',
+        '-f', 'null', '-progress', 'pipe:1', '-nostats', '-'],
+      duration, 'validating', undefined, { startPercent: 95, endPercent: 99 });
+    signal.throwIfAborted();
+    let output: string;
+    for (;;) {
+      output = await uniqueOutput(source, '合并集锦');
+      signal.throwIfAborted();
+      try {
+        // Both paths are on the output volume. A hard link publishes atomically without
+        // overwriting an existing file; non-link filesystems use exclusive copying.
+        try { await link(partial, output); }
+        catch (error) {
+          if ((error as NodeJS.ErrnoException).code === 'EEXIST') throw error;
+          await copyFile(partial, output, constants.COPYFILE_EXCL);
+        }
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      }
+    }
+    if (signal.aborted) {
+      await rm(output, { force: true });
+      signal.throwIfAborted();
+    }
+    terminal = { type: 'batch-export-result', taskId, data: {
+      outputPath: output, mediaUrl: registerMediaPath(output),
+      width: profile.width, height: profile.height, skippedAnalysisIds,
+    } };
+    await logLine(taskId, 'INFO', `Batch export completed: ${output}; segments=${segments.length}; skipped=${skippedAnalysisIds.length}`).catch(() => undefined);
+  } catch (error) {
+    const message = String(error);
+    const code = signal.aborted ? 'EXPORT_CANCELLED'
+      : (error as { exportCode?: string }).exportCode ?? (error instanceof Error ? error.message : 'EXPORT_FAILED');
+    terminal = { type: 'error', taskId, code, message };
+    await logLine(taskId, 'ERROR', `Batch export failed: ${message}`).catch(() => undefined);
+  } finally {
+    if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true }).catch(async (error) => {
+      await logLine(taskId, 'WARN', `Could not clean batch temporary files: ${String(error)}`).catch(() => undefined);
+    });
+    if (signal.aborted && terminal.type === 'batch-export-result') {
+      await rm(terminal.data.outputPath, { force: true }).catch(() => undefined);
+      terminal = { type: 'error', taskId, code: 'EXPORT_CANCELLED', message: 'Batch export cancelled' };
+    }
+    clearExportProgress(taskId);
+    markTaskTerminal(taskId);
+    endTrackedTask(taskId);
+  }
+  send(window, terminal);
+}
+
+export async function startBatchExport(window: BrowserWindow, rawRequest: unknown): Promise<string> {
+  const request = batchExportRequestSchema.parse(rawRequest);
+  const taskId = randomUUID();
+  // Reserve the task slot before asynchronous history/component reads.
+  const controller = beginTrackedTask(taskId);
+  setImmediate(() => { void executeBatchExport(window, taskId, request, controller.signal); });
+  return taskId;
+}

--- a/src/main/batch-media-plan.ts
+++ b/src/main/batch-media-plan.ts
@@ -1,0 +1,93 @@
+import type { CutGroup, VideoMetadata } from '../shared/contracts';
+import type { MediaEncoder } from './components';
+import { videoEncodingOptions } from './media-plan';
+
+function validRate(value: string | null | undefined): boolean {
+  if (!value || !/^\d+\/\d+$/.test(value)) return false;
+  const [numerator, denominator] = value.split('/').map(Number);
+  return Number.isSafeInteger(numerator) && Number.isSafeInteger(denominator)
+    && numerator! > 0 && denominator! > 0;
+}
+
+/** One output specification for every segment, including silent source videos. */
+export function batchOutputProfile(first: VideoMetadata, hasAudio: boolean): VideoMetadata {
+  if (!Number.isFinite(first.fps) || first.fps <= 0) throw new Error('EXPORT_FRAME_RATE_INVALID');
+  const ratio = [first.nominal_fps_ratio, first.average_fps_ratio].find(validRate)
+    ?? `${Math.round(first.fps * 1_000_000)}/1000000`;
+  const [numerator, denominator = 1] = ratio.split('/').map(Number);
+  const fps = numerator! / denominator;
+  if (!Number.isFinite(fps) || fps <= 0) throw new Error('EXPORT_FRAME_RATE_INVALID');
+  return {
+    ...first,
+    width: Math.ceil(first.width / 2) * 2,
+    height: Math.ceil(first.height / 2) * 2,
+    fps, nominal_fps: fps, nominal_fps_ratio: ratio, average_fps_ratio: ratio,
+    variable_frame_rate: false,
+    video_codec: 'h264', pixel_format: 'yuv420p',
+    audio_codec: hasAudio ? 'aac' : null,
+    audio_sample_rate: hasAudio ? 48_000 : null,
+    audio_channels: hasAudio ? 2 : null,
+    audio_bitrate: hasAudio ? 192_000 : null,
+    rotation: 0, sample_aspect_ratio: '1:1',
+    color_space: 'bt709', color_primaries: 'bt709', color_transfer: 'bt709', color_range: 'tv',
+    video_time_base: null, audio_time_base: null,
+  };
+}
+
+export function batchSegmentDuration(group: CutGroup, output: VideoMetadata): number {
+  return Math.max(1, Math.round((group.end - group.start) * output.fps)) / output.fps;
+}
+
+export function buildBatchSegmentArgs(
+  input: VideoMetadata,
+  output: VideoMetadata,
+  group: CutGroup,
+  destination: string,
+  encoder: MediaEncoder,
+): string[] {
+  const duration = batchSegmentDuration(group, output);
+  const rateNumerator = Number(output.nominal_fps_ratio!.split('/')[0]);
+  const trackTimescale = rateNumerator * Math.max(1, Math.ceil(1000 / rateNumerator));
+  const args = [
+    '-hide_banner', '-y', '-autorotate', '-ss', group.start.toFixed(6),
+    '-t', (group.end - group.start).toFixed(6), '-i', input.path,
+  ];
+  const hasAudio = output.audio_codec !== null;
+  if (hasAudio && input.audio_codec === null) {
+    args.push('-f', 'lavfi', '-i', 'anullsrc=r=48000:cl=stereo');
+  }
+  // Supply defaults only for unspecified color metadata. Known source colors are converted,
+  // rather than merely relabelled as the common output color space.
+  const colorDefaults = [
+    ['ispace', input.color_space], ['iprimaries', input.color_primaries], ['itrc', input.color_transfer],
+  ].filter(([, value]) => !value || value === 'unknown' || value === 'unspecified')
+    .map(([key]) => `${key}=bt709`);
+  const videoFilters = [
+    'setpts=PTS-STARTPTS',
+    `scale=${output.width}:${output.height}:force_original_aspect_ratio=decrease:force_divisible_by=2:reset_sar=1`,
+    `pad=${output.width}:${output.height}:(ow-iw)/2:(oh-ih)/2`,
+    'setsar=1',
+    `colorspace=all=bt709:range=tv:format=yuv420p${colorDefaults.length ? `:${colorDefaults.join(':')}` : ''}`,
+    `fps=${output.nominal_fps_ratio}`,
+    `tpad=stop_mode=clone:stop_duration=${(1 / output.fps).toFixed(9)}`,
+    `trim=duration=${duration.toFixed(9)}`,
+    'setpts=PTS-STARTPTS',
+  ];
+  const filters = [`[0:v:0]${videoFilters.join(',')}[vout]`];
+  if (hasAudio) {
+    filters.push(`[${input.audio_codec === null ? '1' : '0'}:a:0]asetpts=PTS-STARTPTS,`
+      + `aresample=48000:async=1:first_pts=0,apad,atrim=duration=${duration.toFixed(9)}[aout]`);
+  }
+  args.push('-filter_complex', filters.join(';'), '-map', '[vout]');
+  if (hasAudio) args.push('-map', '[aout]', '-c:a', 'aac', '-ar', '48000', '-ac', '2', '-b:a', '192000');
+  args.push(
+    ...videoEncodingOptions(output, encoder), '-pix_fmt', 'yuv420p',
+    '-fps_mode:v', 'cfr', '-r', output.nominal_fps_ratio!, '-video_track_timescale', String(trackTimescale),
+    '-color_range', 'tv', '-colorspace', 'bt709', '-color_trc', 'bt709', '-color_primaries', 'bt709',
+    '-map_metadata', '-1', '-metadata:s:v:0', 'rotate=0', '-sn', '-dn',
+    '-t', duration.toFixed(9), '-movflags', '+faststart', '-progress', 'pipe:1', '-nostats',
+  );
+  if (encoder === 'libx264') args.push('-bf', '0');
+  args.push(destination);
+  return args;
+}

--- a/src/main/export.ts
+++ b/src/main/export.ts
@@ -222,7 +222,7 @@ function customArtifactOutputs(request: ExportRequest): {
   };
 }
 
-async function assertExportPreconditions(
+export async function assertExportPreconditions(
   input: string,
   outputDirectory: string,
   taskId: string,
@@ -265,7 +265,11 @@ async function assertExportPreconditions(
   }
 }
 
-async function runFfmpeg(
+export function clearExportProgress(taskId: string): void {
+  lastExportProgress.delete(taskId);
+}
+
+export async function runFfmpeg(
   window: BrowserWindow,
   taskId: string,
   executable: string,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,6 +28,7 @@ import { managedComponentsRoot } from './components';
 import { inspectInstalledComponents, silentlyInspectComponents, startupComponentStatus } from './component-status';
 import { purgeRemovedModelAssets } from './retired-model-assets';
 import { startExport } from './export';
+import { startBatchExport } from './batch-export';
 import { getLogDirectory, logLine } from './logger';
 import { getHistoryStore } from './history';
 import { clearMediaPaths, installMediaProtocol, registerMediaPath } from './media-protocol';
@@ -229,6 +230,9 @@ function registerIpc(): void {
   });
   ipcMain.handle(IPC.exportStart, async (_event, value: unknown) => {
     return startExport(currentWindow(), exportRequestSchema.parse(value));
+  });
+  ipcMain.handle(IPC.batchExportStart, async (_event, value: unknown) => {
+    return startBatchExport(currentWindow(), value);
   });
   ipcMain.handle(IPC.historyList, async () => {
     const entries = await getHistoryStore().list(!hasActiveTasks());

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,6 +24,7 @@ const api: TTcutApi = {
     ipcRenderer.invoke(IPC.analysisStart, input)
   ),
   startExport: (input: ExportRequest) => ipcRenderer.invoke(IPC.exportStart, input),
+  startBatchExport: (input) => ipcRenderer.invoke(IPC.batchExportStart, input),
   listHistory: () => ipcRenderer.invoke(IPC.historyList),
   openHistory: (id: string) => ipcRenderer.invoke(IPC.historyOpen, id),
   deleteHistory: (id: string) => ipcRenderer.invoke(IPC.historyDelete, id),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -202,7 +202,7 @@ export function App() {
         }
         setPoints(event.calibration.points);
         setStep(event.data.rallies.length ? 'mode' : 'empty');
-      } else if (event.type === 'calibration-result') {
+      } else if (event.type === 'calibration-result' || event.type === 'batch-export-result') {
         return;
       } else if (event.type === 'export-result') {
         setActiveTask(null);

--- a/src/renderer/MultiTaskPage.tsx
+++ b/src/renderer/MultiTaskPage.tsx
@@ -5,6 +5,7 @@ import {
   BLURBALL_STAGE1_CONFIDENCE_THRESHOLD_DEFAULT,
   DURATION_HIGHLIGHT_TIER_VALUES,
   AnalysisResultV1,
+  BatchExportResult,
   BlurBallAnalysisMode,
   Calibration,
   CutSelectionV1,
@@ -30,6 +31,7 @@ type PointName = keyof Calibration['points'];
 
 type BatchItem = {
   id: string;
+  additionOrder: number;
   video: SelectedVideo;
   previewVideo: SelectedVideo | null;
   metadata: VideoMetadata;
@@ -72,9 +74,10 @@ function makeId(video: SelectedVideo): string {
   return `${video.path}:${video.size}:${Date.now()}:${Math.random()}`;
 }
 
-async function createItems(videos: SelectedVideo[]): Promise<BatchItem[]> {
-  return Promise.all(videos.map(async (video) => ({
+async function createItems(videos: SelectedVideo[], firstOrder = 0): Promise<BatchItem[]> {
+  return Promise.all(videos.map(async (video, index) => ({
     id: makeId(video),
+    additionOrder: firstOrder + index,
     video,
     previewVideo: null,
     metadata: await window.ttcut.probeVideo(video.path),
@@ -142,6 +145,18 @@ export function MultiTaskPage({
   const [manualPoints, setManualPoints] = useState<Partial<Record<PointName, [number, number]>>>({});
   const [systemNotice, setSystemNotice] = useState<string | null>(null);
   const [shutdownAfterCompletion, setShutdownAfterCompletion] = useState(false);
+  const [mergeVideos, setMergeVideos] = useState(false);
+  const [batchExport, setBatchExport] = useState<{
+    status: 'idle' | 'blocked' | 'exporting' | 'done' | 'failed' | 'cancelled' | 'empty';
+    progress: number;
+    result: BatchExportResult | null;
+    error: string | null;
+  }>({ status: 'idle', progress: 0, result: null, error: null });
+  const mergeVideosRef = useRef(false);
+  const mergeRunRef = useRef(false);
+  const batchExportRef = useRef<{ taskId: string | null; cancelRequested: boolean } | null>(null);
+  const nextAdditionOrder = useRef(initialVideos.length);
+  const pendingAdditions = useRef(0);
   const itemsRef = useRef(items);
   const activeRef = useRef<{ taskId: string | null; itemId: string; phase: ActivePhase } | null>(null);
   const runningRef = useRef(false);
@@ -182,6 +197,20 @@ export function MultiTaskPage({
     running: isEnglish ? 'Processing serially' : '正在串行处理',
     shutdownAfterTask: isEnglish ? 'Shut down after this task' : '完成本任务后关机',
     shutdownFailed: isEnglish ? 'Automatic shutdown failed. Please shut down manually.' : '自动关机失败，请手动关机。',
+    merge: isEnglish ? 'Merge into one video' : '合并为一个视频',
+    mergeUnavailable: isEnglish ? 'Choose all rallies or highlights for at least one video.' : '至少一个视频选择“所有回合”或“精彩回合”后可用。',
+    merging: isEnglish ? 'Exporting merged video' : '正在合并导出',
+    mergeWaiting: isEnglish ? 'Analyzed · waiting to merge' : '分析完成 · 等待合并',
+    mergeDone: isEnglish ? 'Merged video ready' : '合并视频已完成',
+    mergeBlocked: isEnglish ? 'Finish, retry or remove incomplete videos before merging.' : '请完成标定、重试或移除未完成的视频后再合并。',
+    mergeEmpty: isEnglish ? 'No clips to merge' : '没有可合并的片段',
+    mergeFailed: isEnglish ? 'Merged export failed. You can retry without reanalyzing.' : '合并导出失败，可直接重试，无需重新分析。',
+    mergeCancelled: isEnglish ? 'Merged export cancelled. Analysis results are retained.' : '已取消合并导出，分析结果已保留。',
+    mergeSkipped: isEnglish ? 'No matching clips; skipped:' : '没有符合条件的片段，已跳过：',
+    retry: isEnglish ? 'Retry merge' : '重试合并',
+    viewAnalysis: isEnglish ? 'View analysis' : '查看分析',
+    previewOutput: isEnglish ? 'Preview output' : '预览输出',
+    openFolder: isEnglish ? 'Open folder' : '打开文件夹',
     calibrationTitle: isEnglish ? 'Calibrate the table' : '标定球桌',
     calibrationDescription: isEnglish
       ? 'Mark the four table corners in any order. Drag a point to fine-tune it.'
@@ -204,12 +233,67 @@ export function MultiTaskPage({
   useEffect(() => { itemsRef.current = items; }, [items]);
   useEffect(() => { runningRef.current = running; }, [running]);
   const batchTaskActive = !initialized || running || hasOpenBatchWork(items);
+  const mergeWorkflow = mergeVideos || (running && mergeRunRef.current);
+  const exportLocked = batchExport.status === 'exporting';
+  const hasClippingItems = items.some((item) => item.mode !== 'analyze-only');
   useEffect(() => onTaskStateChange(batchTaskActive), [batchTaskActive, onTaskStateChange]);
 
   const replaceItems = (updater: (current: BatchItem[]) => BatchItem[]) => {
     const next = updater(itemsRef.current);
     itemsRef.current = next;
     setItems(next);
+    const hasClipping = next.some((item) => item.mode !== 'analyze-only');
+    if (!hasClipping || (runningRef.current && mergeRunRef.current)) {
+      mergeVideosRef.current = hasClipping && mergeRunRef.current;
+      setMergeVideos(mergeVideosRef.current);
+    }
+  };
+
+  const invalidateMergedOutput = () => {
+    setBatchExport({ status: 'idle', progress: 0, result: null, error: null });
+  };
+
+  const selectionFor = (item: BatchItem): Exclude<CutSelectionV1, { mode: 'custom' }> => item.mode === 'all'
+    ? { mode: 'all', pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll }
+    : optionsRef.current.rallyRecognitionMethod === 'continuous_visibility'
+      ? { mode: 'highlight', criterion: { kind: 'duration_tier', tier: item.durationTier }, pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll }
+      : { mode: 'highlight', criterion: { kind: 'bounce_count', threshold: item.threshold }, pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll };
+
+  const completeRun = (success: boolean) => {
+    const canShutdown = !mergeRunRef.current || itemsRef.current.every((item) => !item.exportWarning);
+    runningRef.current = false;
+    mergeRunRef.current = false;
+    setRunning(false);
+    if (!success) return;
+    onCompletableTasksFinished();
+    if (shutdownAfterCompletionRef.current && canShutdown) {
+      shutdownAfterCompletionRef.current = false;
+      setShutdownAfterCompletion(false);
+      void window.ttcut.shutdownSystem().catch(() => setSystemNotice(text.shutdownFailed));
+    }
+  };
+
+  const beginMergedExport = () => {
+    // Lock synchronously before the IPC call and snapshot conditions in stable source order.
+    batchExportRef.current = { taskId: null, cancelRequested: false };
+    setBatchExport({ status: 'exporting', progress: 0, result: null, error: null });
+    const participants = itemsRef.current.filter((item) => item.mode !== 'analyze-only')
+      .sort((left, right) => left.additionOrder - right.additionOrder);
+    const promise = window.ttcut.startBatchExport({ items: participants.map((item) => ({
+      analysis_id: item.analysisId!, selection: selectionFor(item),
+    })) });
+    pendingTaskStartRef.current = promise;
+    void promise.then((taskId) => {
+      if (!batchExportRef.current) return;
+      batchExportRef.current.taskId = taskId;
+      if (batchExportRef.current.cancelRequested) void window.ttcut.cancelTask(taskId);
+    }).catch((error) => {
+      batchExportRef.current = null;
+      setBatchExport({ status: 'failed', progress: 0, result: null, error: String(error) });
+      completeRun(false);
+    }).finally(() => {
+      if (pendingTaskStartRef.current === promise) pendingTaskStartRef.current = null;
+    });
   };
 
   const updateItem = (id: string, updater: (item: BatchItem) => BatchItem) => {
@@ -223,7 +307,7 @@ export function MultiTaskPage({
   };
 
   const schedule = () => {
-    if (activeRef.current) return;
+    if (activeRef.current || batchExportRef.current) return;
     const calibrationCandidate = itemsRef.current.find((item) => item.calibrationStatus === 'pending');
     if (calibrationCandidate) {
       if (!autoCalibrationAvailableRef.current) {
@@ -264,16 +348,27 @@ export function MultiTaskPage({
       && item.processingStatus === 'waiting'
     ));
     if (!candidate) {
+      if (pendingAdditions.current > 0) return;
       const completedSuccessfully = itemsRef.current.length > 0
         && itemsRef.current.every((item) => item.processingStatus === 'done');
-      runningRef.current = false;
-      setRunning(false);
-      onCompletableTasksFinished();
-      if (completedSuccessfully && shutdownAfterCompletionRef.current) {
-        shutdownAfterCompletionRef.current = false;
-        setShutdownAfterCompletion(false);
-        void window.ttcut.shutdownSystem().catch(() => setSystemNotice(text.shutdownFailed));
+      if (mergeRunRef.current) {
+        if (!completedSuccessfully) {
+          setBatchExport({ status: 'blocked', progress: 0, result: null, error: null });
+          completeRun(false);
+        } else if (itemsRef.current.some((item) => item.mode !== 'analyze-only')) {
+          beginMergedExport();
+        } else {
+          completeRun(true);
+        }
+      } else {
+        completeRun(completedSuccessfully);
+        if (!completedSuccessfully) onCompletableTasksFinished();
       }
+      return;
+    }
+    if (mergeRunRef.current && candidate.analysisId && candidate.analysis) {
+      updateItem(candidate.id, (item) => ({ ...item, processingStatus: 'done', progress: 100 }));
+      setTimeout(() => scheduleRef.current(), 0);
       return;
     }
     cancelRequested.current = false;
@@ -282,11 +377,7 @@ export function MultiTaskPage({
       updateItem(candidate.id, (item) => ({ ...item, processingStatus: 'exporting', progress: 70, error: null }));
       activeRef.current = { taskId: null, itemId: candidate.id, phase: 'export' };
       setActivePhase('export');
-      const selection: CutSelectionV1 = candidate.mode === 'all'
-        ? { mode: 'all', pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll }
-        : optionsRef.current.rallyRecognitionMethod === 'continuous_visibility'
-          ? { mode: 'highlight', criterion: { kind: 'duration_tier', tier: candidate.durationTier }, pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll }
-          : { mode: 'highlight', criterion: { kind: 'bounce_count', threshold: candidate.threshold }, pre_roll_seconds: optionsRef.current.preRoll, post_roll_seconds: optionsRef.current.postRoll };
+      const selection = selectionFor(candidate);
       const startPromise = window.ttcut.startExport({
         analysis_id: candidate.analysisId,
         selection,
@@ -335,7 +426,7 @@ export function MultiTaskPage({
       videoPath: candidate.video.path,
       calibrationChoice,
       device: 'auto',
-      historyVisibility: candidate.mode === 'analyze-only' ? 'visible' : 'deferred',
+      historyVisibility: mergeRunRef.current || candidate.mode === 'analyze-only' ? 'visible' : 'deferred',
       analysisMode: optionsRef.current.rallyRecognitionMethod === 'continuous_visibility' ? 'full' : optionsRef.current.analysisMode,
       rallyRecognitionMethod: optionsRef.current.rallyRecognitionMethod,
       normalizeVariableFrameRate: optionsRef.current.normalizeVariableFrameRate,
@@ -390,15 +481,35 @@ export function MultiTaskPage({
   }, [items]);
 
   useEffect(() => window.ttcut.onTaskEvent((event: AppEvent) => {
+    if (event.type === 'component-result') return;
+    const eventTaskId = event.type === 'progress' ? event.data.taskId : event.taskId;
+    if (batchExportRef.current?.taskId === eventTaskId) {
+      if (event.type === 'progress') {
+        setBatchExport((current) => ({ ...current, progress: Math.max(current.progress, event.data.percent) }));
+      } else if (event.type === 'batch-export-result') {
+        batchExportRef.current = null;
+        setBatchExport({ status: 'done', progress: 100, result: event.data, error: null });
+        completeRun(true);
+      } else if (event.type === 'error') {
+        batchExportRef.current = null;
+        setBatchExport({
+          status: event.code === 'BATCH_EXPORT_EMPTY' ? 'empty' : event.code === 'EXPORT_CANCELLED' ? 'cancelled' : 'failed',
+          progress: 0, result: null, error: event.code,
+        });
+        completeRun(false);
+      }
+      return;
+    }
+    if (event.type === 'batch-export-result') return;
     const active = activeRef.current;
-    if (!active || event.type === 'component-result') return;
+    if (!active) return;
     const taskId = event.type === 'progress' ? event.data.taskId : event.taskId;
     if (active.taskId !== taskId) return;
     if (event.type === 'progress') {
       const mapped = active.phase === 'calibration'
         ? overallCalibrationProgress(event.data.stage, event.data.percent)
         : active.phase === 'analysis'
-          ? (itemsRef.current.find((item) => item.id === active.itemId)?.mode === 'analyze-only'
+          ? (mergeRunRef.current || itemsRef.current.find((item) => item.id === active.itemId)?.mode === 'analyze-only'
             ? event.data.percent
             : event.data.stage === 'video_normalization'
               ? event.data.percent
@@ -422,7 +533,7 @@ export function MultiTaskPage({
     }
     if (event.type === 'analysis-result') {
       const current = itemsRef.current.find((item) => item.id === active.itemId);
-      const finishedAtAnalysis = current?.mode === 'analyze-only' || event.data.rallies.length === 0;
+      const finishedAtAnalysis = mergeRunRef.current || current?.mode === 'analyze-only' || event.data.rallies.length === 0;
       updateItem(active.itemId, (item) => ({
         ...item,
         analysisId: event.analysisId,
@@ -509,26 +620,55 @@ export function MultiTaskPage({
   }), []);
 
   const addVideos = async (videos: SelectedVideo[]) => {
+    if (batchExportRef.current) return;
     const existing = new Set(itemsRef.current.map((item) => item.video.path.toLowerCase()));
     const unique = videos.filter((video) => !existing.has(video.path.toLowerCase()));
     if (!unique.length) return;
-    const created = await createItems(unique);
-    const added = autoCalibrationAvailableRef.current
-      ? created
-      : created.map((item) => ({ ...item, calibrationStatus: 'manual-required' as const }));
-    replaceItems((current) => {
-      const currentPaths = new Set(current.map((item) => item.video.path.toLowerCase()));
-      return [...current, ...added.filter((item) => !currentPaths.has(item.video.path.toLowerCase()))];
-    });
-    setTimeout(() => scheduleRef.current(), 0);
+    const firstOrder = nextAdditionOrder.current;
+    nextAdditionOrder.current += unique.length;
+    pendingAdditions.current += 1;
+    try {
+      const created = await createItems(unique, firstOrder);
+      if (batchExportRef.current) return;
+      const added = autoCalibrationAvailableRef.current
+        ? created
+        : created.map((item) => ({ ...item, calibrationStatus: 'manual-required' as const }));
+      invalidateMergedOutput();
+      replaceItems((current) => {
+        const currentPaths = new Set(current.map((item) => item.video.path.toLowerCase()));
+        return [...current, ...added.filter((item) => !currentPaths.has(item.video.path.toLowerCase()))];
+      });
+    } catch (error) {
+      setSystemNotice(String(error));
+    } finally {
+      pendingAdditions.current -= 1;
+      setTimeout(() => scheduleRef.current(), 0);
+    }
   };
 
-  const chooseMore = async () => addVideos(await window.ttcut.selectVideos());
+  const collectVideos = async (select: () => Promise<SelectedVideo[]>) => {
+    if (batchExportRef.current) return;
+    pendingAdditions.current += 1;
+    try {
+      await addVideos(await select());
+    } catch (error) {
+      setSystemNotice(String(error));
+    } finally {
+      pendingAdditions.current -= 1;
+      setTimeout(() => scheduleRef.current(), 0);
+    }
+  };
+
+  const chooseMore = () => collectVideos(() => window.ttcut.selectVideos());
   const start = () => {
-    if (runningRef.current || hasPendingCalibration(itemsRef.current)) return;
+    if (runningRef.current || batchExportRef.current || hasPendingCalibration(itemsRef.current)) return;
     cancelRequested.current = false;
+    mergeRunRef.current = mergeVideosRef.current;
+    invalidateMergedOutput();
     replaceItems((current) => current.map((item) => (
       item.processingStatus === 'failed' || item.processingStatus === 'cancelled'
+        || (!mergeRunRef.current && item.processingStatus === 'done' && item.mode !== 'analyze-only'
+          && item.analysis && item.analysis.rallies.length > 0 && !item.outputPath)
         ? { ...item, processingStatus: 'waiting', recoveredOutputPath: null, exportWarning: null, error: null }
         : item
     )));
@@ -542,6 +682,26 @@ export function MultiTaskPage({
     setShutdownAfterCompletion(enabled);
   };
 
+  const toggleMerge = (enabled: boolean) => {
+    if (runningRef.current || batchExportRef.current) return;
+    mergeVideosRef.current = enabled;
+    setMergeVideos(enabled);
+    invalidateMergedOutput();
+  };
+
+  const changeSelection = (id: string, updater: (item: BatchItem) => BatchItem) => {
+    if (batchExportRef.current) return;
+    invalidateMergedOutput();
+    updateItem(id, updater);
+  };
+
+  const cancelMergedExport = () => {
+    const active = batchExportRef.current;
+    if (!active) return;
+    active.cancelRequested = true;
+    if (active.taskId) void window.ttcut.cancelTask(active.taskId);
+  };
+
   const cancel = async () => {
     const active = activeRef.current;
     if (!active?.taskId || active.phase === 'calibration') return;
@@ -550,9 +710,10 @@ export function MultiTaskPage({
   };
 
   const remove = async (item: BatchItem) => {
-    if (item.id === activeItem) return;
-    if (item.analysisId) await window.ttcut.deleteAnalysis(item.analysisId);
+    if (item.id === activeRef.current?.itemId || batchExportRef.current) return;
+    invalidateMergedOutput();
     replaceItems((current) => current.filter((value) => value.id !== item.id));
+    if (item.analysisId) await window.ttcut.deleteAnalysis(item.analysisId);
     setTimeout(() => scheduleRef.current(), 0);
   };
 
@@ -617,7 +778,11 @@ export function MultiTaskPage({
 
   const ordered = [...items].sort((left, right) => Number(right.processingStatus === 'done') - Number(left.processingStatus === 'done'));
   const calibrationBusy = hasPendingCalibration(items);
-  const canStart = items.some((item) => item.calibrationStatus === 'ready' && item.processingStatus !== 'done');
+  const canStart = items.some((item) => item.calibrationStatus === 'ready' && (
+    item.processingStatus !== 'done'
+    || (mergeVideos && hasClippingItems && batchExport.status !== 'done')
+    || (!mergeVideos && item.mode !== 'analyze-only' && item.analysis && item.analysis.rallies.length > 0 && !item.outputPath)
+  ));
 
   return (
     <section
@@ -625,14 +790,14 @@ export function MultiTaskPage({
       onDragOver={(event) => event.preventDefault()}
       onDrop={(event) => {
         event.preventDefault();
+        if (batchExportRef.current) return;
         const files = [...event.dataTransfer.files].filter((file) => isSupportedVideoFileName(file.name));
-        void Promise.all(files.map((file) => window.ttcut.acceptDroppedVideo(window.ttcut.pathForDroppedFile(file))))
-          .then(addVideos);
+        void collectVideos(() => Promise.all(files.map((file) => window.ttcut.acceptDroppedVideo(window.ttcut.pathForDroppedFile(file)))));
       }}
     >
       <div className="multi-header">
         <h1>{text.title}</h1>
-        <button className="secondary" type="button" onClick={() => void chooseMore()}>{text.add}</button>
+        <button className="secondary" type="button" disabled={exportLocked} onClick={() => void chooseMore()}>{text.add}</button>
       </div>
       {systemNotice && <div className="notice batch-system-notice" role="status"><strong>{systemNotice}</strong></div>}
       <div className="batch-list">
@@ -679,6 +844,11 @@ export function MultiTaskPage({
               <div className="batch-info">
                 <strong title={item.video.name}>{item.video.name}</strong>
                 <span>{formatTimestamp(item.metadata.duration_seconds)} · {item.metadata.width} × {item.metadata.height} · {item.metadata.fps.toFixed(3)} fps</span>
+                {mergeWorkflow && done && item.mode !== 'analyze-only' && batchExport.status !== 'done' && <span>{text.mergeWaiting}</span>}
+                {mergeWorkflow && item.analysisId && (
+                  <button className="text-button" type="button" disabled={batchTaskActive}
+                    onClick={() => onOpenAnalysis(item.analysisId!)}>{text.viewAnalysis}</button>
+                )}
                 {item.error && !manualRequired && <small>{item.error}</small>}
                 {item.exportWarning && (
                   <div className="batch-export-warning" role="alert">
@@ -687,7 +857,7 @@ export function MultiTaskPage({
                   </div>
                 )}
               </div>
-              {done ? (
+              {done && !mergeWorkflow ? (
                 <div className="batch-actions">
                   <button className="secondary" type="button" disabled={!item.outputMediaUrl && batchTaskActive} onClick={() => item.outputMediaUrl ? setPreview({
                     source: item.outputMediaUrl,
@@ -700,7 +870,7 @@ export function MultiTaskPage({
               ) : item.processingStatus === 'failed' && item.recoveredOutputPath ? (
                 <div className="batch-actions">
                   <button className="secondary" type="button" onClick={() => void window.ttcut.revealOutput(item.recoveredOutputPath!)}>{text.openRecovered}</button>
-                  <button className="batch-remove" type="button" aria-label={`${text.remove} ${item.video.name}`} disabled={active} onClick={() => void remove(item)}>×</button>
+                  <button className="batch-remove" type="button" aria-label={`${text.remove} ${item.video.name}`} disabled={active || exportLocked} onClick={() => void remove(item)}>×</button>
                 </div>
               ) : (
                 <>
@@ -716,8 +886,8 @@ export function MultiTaskPage({
                           type="button"
                           className={item.mode === mode ? 'selected' : ''}
                           aria-pressed={item.mode === mode}
-                          disabled={active && activePhase !== 'calibration'}
-                          onClick={() => updateItem(item.id, (value) => ({ ...value, mode }))}
+                          disabled={exportLocked || (!mergeWorkflow && active && activePhase !== 'calibration')}
+                          onClick={() => changeSelection(item.id, (value) => ({ ...value, mode }))}
                         >
                           {label}
                         </button>
@@ -726,47 +896,90 @@ export function MultiTaskPage({
                     {item.mode === 'highlight' && (rallyRecognitionMethod === 'continuous_visibility' ? <GlassRadioGroup
                       ariaLabel={language === 'zh-CN' ? '时长档位' : 'Duration tier'}
                       className="compact"
-                      disabled={active}
+                      disabled={exportLocked || (!mergeWorkflow && active)}
                       idPrefix={`batch-duration-tier-${item.id}`}
                       name={`batch-duration-tier-${item.id}`}
-                      onChange={(durationTier) => updateItem(item.id, (current) => ({ ...current, durationTier }))}
+                      onChange={(durationTier) => changeSelection(item.id, (current) => ({ ...current, durationTier }))}
                       options={DURATION_HIGHLIGHT_TIER_VALUES.map((value) => ({ value, label: ({ short_rally: language === 'zh-CN' ? '短回合' : 'Short rally', rally: language === 'zh-CN' ? '相持' : 'Rally', long_rally: language === 'zh-CN' ? '长相持' : 'Long rally' } as const)[value] }))}
                       value={item.durationTier}
                     /> : <GlassRadioGroup
                       ariaLabel={language === 'zh-CN' ? '板数筛选' : 'Bounce filter'}
                       className="compact"
-                      disabled={active}
+                      disabled={exportLocked || (!mergeWorkflow && active)}
                       idPrefix={`batch-threshold-${item.id}`}
                       name={`batch-threshold-${item.id}`}
-                      onChange={(threshold) => updateItem(item.id, (current) => ({ ...current, threshold }))}
+                      onChange={(threshold) => changeSelection(item.id, (current) => ({ ...current, threshold }))}
                       options={([3, 5, 7] as const).map((value) => ({ value, label: `${value}${language === 'zh-CN' ? '板' : ' bounces'}` }))}
                       value={item.threshold}
                     />)}
                   </div>
-                  <button className="batch-remove" type="button" aria-label={`${text.remove} ${item.video.name}`} disabled={active} onClick={() => void remove(item)}>×</button>
+                  <button className="batch-remove" type="button" aria-label={`${text.remove} ${item.video.name}`} disabled={active || exportLocked} onClick={() => void remove(item)}>×</button>
                 </>
               )}
             </article>
           );
         })}
       </div>
-      <div className={`batch-launcher floating-launcher ${shutdownAfterCompletion ? 'shutdown-armed' : ''}`}>
-        <label className="batch-shutdown-option floating-launch-options">
-          <input
-            type="checkbox"
-            checked={shutdownAfterCompletion}
-            disabled={!batchTaskActive}
-            onChange={(event) => toggleShutdownAfterCompletion(event.target.checked)}
-          />
-          <span>{text.shutdownAfterTask}</span>
-        </label>
+      {batchExport.status !== 'idle' && (
+        <div className="batch-merged-result card" role="status">
+          <strong>{({
+            blocked: text.mergeBlocked, exporting: text.merging, done: text.mergeDone,
+            failed: text.mergeFailed, cancelled: text.mergeCancelled, empty: text.mergeEmpty,
+          })[batchExport.status]}</strong>
+          {exportLocked && <>
+            <progress aria-label={text.merging} max={100} value={batchExport.progress} />
+            <span>{Math.round(batchExport.progress)}%</span>
+            <button className="secondary" type="button" onClick={cancelMergedExport}>{text.cancel}</button>
+          </>}
+          {batchExport.error && batchExport.status === 'failed' && <>
+            <small>{batchExport.error}</small>
+            <button className="text-button" type="button" onClick={() => void window.ttcut.revealLogs()}>{text.logs}</button>
+          </>}
+          {['blocked', 'failed', 'cancelled', 'empty'].includes(batchExport.status) && (
+            <button className="secondary" type="button" disabled={!canStart || calibrationBusy || running} onClick={start}>{text.retry}</button>
+          )}
+          {batchExport.result && <>
+            <span className="batch-merged-path">{batchExport.result.outputPath}</span>
+            {batchExport.result.skippedAnalysisIds.length > 0 && <span>{text.mergeSkipped}{items
+              .filter((item) => item.analysisId && batchExport.result!.skippedAnalysisIds.includes(item.analysisId))
+              .map((item) => item.video.name).join('、')}</span>}
+            <div className="batch-actions">
+              <button className="secondary" type="button" onClick={() => setPreview({
+                source: batchExport.result!.mediaUrl, name: text.mergeDone,
+                width: batchExport.result!.width, height: batchExport.result!.height,
+              })}>{text.previewOutput}</button>
+              <button className="secondary" type="button" onClick={() => void window.ttcut.revealOutput(batchExport.result!.outputPath)}>{text.openFolder}</button>
+            </div>
+          </>}
+        </div>
+      )}
+      <div className={`batch-launcher floating-launcher ${shutdownAfterCompletion ? 'shutdown-armed' : ''}`}
+        tabIndex={0} aria-label={isEnglish ? 'Batch task options' : '多任务选项'}>
+        <div className="batch-launch-options custom-export-options floating-launch-options">
+          <label className="export-checkbox" title={!hasClippingItems ? text.mergeUnavailable : undefined}>
+            <input type="checkbox" checked={mergeVideos} disabled={running || exportLocked || !hasClippingItems}
+              onChange={(event) => toggleMerge(event.target.checked)} />
+            <span className="export-checkbox-control" aria-hidden="true"><span className="export-checkbox-gloss" /></span>
+            <span className="export-checkbox-text">{text.merge}</span>
+          </label>
+          <label className="export-checkbox">
+            <input
+              type="checkbox"
+              checked={shutdownAfterCompletion}
+              disabled={!batchTaskActive && !canStart}
+              onChange={(event) => toggleShutdownAfterCompletion(event.target.checked)}
+            />
+            <span className="export-checkbox-control" aria-hidden="true"><span className="export-checkbox-gloss" /></span>
+            <span className="export-checkbox-text">{text.shutdownAfterTask}</span>
+          </label>
+        </div>
         <button
           className="batch-start primary floating-launch-start"
           type="button"
           disabled={running || calibrationBusy || !canStart}
           onClick={start}
         >
-          {activePhase === 'calibration' ? text.calibrating : running ? text.running : text.start}
+          {exportLocked ? text.merging : activePhase === 'calibration' ? text.calibrating : running ? text.running : text.start}
           {shutdownAfterCompletion && <span className="batch-shutdown-indicator" aria-hidden="true">⏻</span>}
         </button>
       </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -531,16 +531,16 @@ td input { accent-color: var(--blue); }
 .batch-remove { width: 34px; height: 34px; border: 0; border-radius: 9px; background: transparent; color: var(--muted); cursor: pointer; font-size: 22px; }
 .batch-remove:hover { background: #fff0ef; color: #a1261f; }
 .batch-actions { display: flex; gap: 8px; justify-content: flex-end; }
-.batch-shutdown-option {
-  min-height: 34px; padding: 0 12px; display: flex; align-items: center; gap: 7px;
-  border: 1px solid var(--line); border-radius: 7px; background: rgba(255, 255, 255, .97); box-shadow: 0 8px 20px rgba(0, 0, 0, .12);
-  color: var(--text); font-size: 12px; font-weight: 400; cursor: pointer;
-}
-.batch-shutdown-option input { width: 14px; height: 14px; margin: 0; accent-color: var(--blue); cursor: pointer; }
-.batch-shutdown-option:has(input:disabled) { color: var(--muted); cursor: default; }
-.batch-shutdown-option input:disabled { cursor: default; }
 .batch-launcher.shutdown-armed .batch-start { box-shadow: 0 0 0 2px rgba(194, 110, 26, .38), 0 12px 32px rgba(45, 112, 220, .3); }
 .batch-shutdown-indicator { display: inline-block; margin-left: 8px; font-size: 14px; line-height: 1; }
+.batch-launcher { width: max-content; margin: 16px 0 0 auto; }
+.batch-launch-options { visibility: hidden; }
+.batch-launcher::before { content: ''; position: absolute; right: 0; bottom: 100%; width: 100%; height: 8px; }
+.batch-launcher:hover .batch-launch-options, .batch-launcher:focus-within .batch-launch-options { opacity: 1; visibility: visible; pointer-events: auto; transform: translateY(0) scale(1); }
+.batch-launcher:focus-visible { outline: 2px solid var(--blue); outline-offset: 4px; border-radius: 24px; }
+.batch-merged-result { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; padding: 16px; }
+.batch-merged-result progress { flex: 1; min-width: 120px; accent-color: var(--blue); }
+.batch-merged-path { width: 100%; overflow-wrap: anywhere; color: var(--muted); }
 .batch-system-notice { width: 100%; margin: 0 0 16px; }
 .multi-calibration-page { width: min(980px, 100%); margin: 0 auto; }
 .multi-calibration-page .multi-header { align-items: center; }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,5 +1,7 @@
 import type {
   AnalysisResultV1,
+  BatchExportRequest,
+  BatchExportResult,
   AppSettings,
   BlurBallAnalysisMode,
   RallyRecognitionMethod,
@@ -49,6 +51,7 @@ export type AppEvent =
   | { type: 'analysis-result'; taskId: string; analysisId: string; calibration: Calibration; data: AnalysisResultV1 }
   | { type: 'calibration-result'; taskId: string; calibration: Calibration; tableAnalysis: TableAnalysis }
   | { type: 'export-result'; taskId: string; data: ExportResult }
+  | { type: 'batch-export-result'; taskId: string; data: BatchExportResult }
   | {
     type: 'component-result';
     taskId: string;
@@ -104,6 +107,7 @@ export interface TTcutApi {
     blurballStage2ConfidenceThreshold: number;
   }): Promise<string>;
   startExport(input: ExportRequest): Promise<string>;
+  startBatchExport(input: BatchExportRequest): Promise<string>;
   listHistory(): Promise<HistorySummaryV1[]>;
   openHistory(id: string): Promise<HistoryOpenResultV1>;
   deleteHistory(id: string): Promise<void>;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -680,6 +680,24 @@ export const exportRequestSchema = z.object({
   }
 });
 
+export const batchExportRequestSchema = z.object({
+  items: z.array(z.object({
+    analysis_id: z.string().uuid(),
+    selection: z.union([allCutSelectionSchema, legacyHighlightCutSelectionSchema, highlightCutSelectionSchema]),
+  }).strict()).min(1),
+}).strict().refine((request) => new Set(request.items.map((item) => item.analysis_id)).size === request.items.length, {
+  message: 'Batch export analyses must be unique',
+});
+
+export type BatchExportRequest = z.infer<typeof batchExportRequestSchema>;
+export type BatchExportResult = {
+  outputPath: string;
+  mediaUrl: string;
+  width: number;
+  height: number;
+  skippedAnalysisIds: string[];
+};
+
 export const updateStateSchema = z.object({
   status: z.enum(['idle', 'unsupported', 'checking', 'available', 'downloaded', 'up-to-date', 'error']),
   version: z.string().min(1).nullable(),

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -14,6 +14,7 @@ export const IPC = {
   calibrationStart: 'calibration:start',
   analysisStart: 'analysis:start',
   exportStart: 'export:start',
+  batchExportStart: 'export:batch-start',
   historyList: 'history:list',
   historyOpen: 'history:open',
   historyDelete: 'history:delete',

--- a/tests/batch-export.integration.test.ts
+++ b/tests/batch-export.integration.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import type { BrowserWindow } from 'electron';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { AppEvent } from '../src/shared/api';
+import type { HistoryRecordV1 } from '../src/shared/contracts';
+
+const state = vi.hoisted(() => ({ records: new Map<string, HistoryRecordV1>(), events: [] as AppEvent[] }));
+vi.mock('electron', () => ({ dialog: {} }));
+vi.mock('../src/main/logger', () => ({ logLine: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../src/main/media-protocol', () => ({ registerMediaPath: (value: string) => value }));
+vi.mock('../src/main/history', () => ({ getHistoryStore: () => ({ open: async (id: string) => state.records.get(id) }) }));
+vi.mock('../src/main/components', () => ({ resolveUsableMediaComponents: async () => ({
+  ffmpeg: process.env.TTCUT_FFMPEG_INTEGRATION,
+  ffprobe: process.env.TTCUT_FFPROBE_INTEGRATION,
+  mediaEncoder: process.env.TTCUT_BATCH_ENCODER ?? 'libopenh264',
+}) }));
+
+import { startBatchExport } from '../src/main/batch-export';
+import { cancelAllTasksAndWait, runProcess } from '../src/main/processes';
+import { probeVideo } from '../src/main/probe';
+import { createCutGroups } from '../src/domain/segments';
+
+const ffmpeg = process.env.TTCUT_FFMPEG_INTEGRATION;
+const enabled = Boolean(ffmpeg && process.env.TTCUT_FFPROBE_INTEGRATION);
+const selection = { mode: 'all', pre_roll_seconds: 1.5, post_roll_seconds: 0.5 } as const;
+
+describe.skipIf(!enabled)('real cross-video merged export', () => {
+  let root: string;
+  const ids = [1, 2, 3, 4].map((id) => `${id}1111111-1111-4111-8111-111111111111`);
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(process.env.TTCUT_BATCH_TEST_ROOT ?? tmpdir(), 'ttcut-merged-media-'));
+    const encoder = process.env.TTCUT_BATCH_ENCODER ?? 'libopenh264';
+    const configs = [
+      { name: 'red.mp4', color: 'red', size: '320x180', rate: '30000/1001', audio: true, vfr: false },
+      { name: 'green.mp4', color: 'lime', size: '180x320', rate: '24', audio: false, vfr: false },
+      { name: 'blue-raw.mp4', color: 'blue', size: '320x180', rate: '25', audio: false, vfr: false },
+      { name: 'yellow.mp4', color: 'yellow', size: '256x144', rate: '30', audio: true, vfr: true },
+    ];
+    for (const [index, config] of configs.entries()) {
+      let file = path.join(root, config.name);
+      const args = ['-hide_banner', '-y', '-f', 'lavfi', '-i', `color=c=${config.color}:s=${config.size}:r=${config.rate}:d=4`];
+      if (config.audio) args.push('-f', 'lavfi', '-i', 'sine=frequency=440:sample_rate=44100:duration=4');
+      if (config.vfr) args.push('-vf', "select='not(mod(n,2))+not(mod(n,5))'", '-fps_mode', 'vfr');
+      args.push('-c:v', encoder, '-b:v', '1000000', '-pix_fmt', 'yuv420p');
+      if (config.audio) args.push('-c:a', 'aac');
+      args.push(file);
+      await runProcess(ffmpeg!, args);
+      if (index === 2) {
+        const rotated = path.join(root, 'blue-rotated.mp4');
+        await runProcess(ffmpeg!, ['-hide_banner', '-y', '-display_rotation:v:0', '90', '-i', file, '-c', 'copy', rotated]);
+        file = rotated;
+      }
+      const video = await probeVideo(file);
+      state.records.set(ids[index]!, {
+        id: ids[index]!, source: { path: file, name: path.basename(file), size: 1, modified_time_ms: 1 },
+        analysis: { schema_version: 1, video, rallies: [{
+          id: 'rally_001', index: 1, bounce_count: 5, start_time_seconds: 2, end_time_seconds: 2.2,
+        }] },
+      } as HistoryRecordV1);
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await cancelAllTasksAndWait();
+    if (root && !process.env.TTCUT_BATCH_TEST_ROOT) await rm(root, { recursive: true, force: true });
+  });
+
+  function pixel(file: string, seconds: number, x = 160, y = 90): number[] {
+    const result = spawnSync(ffmpeg!, ['-v', 'error', '-ss', String(seconds), '-i', file,
+      '-frames:v', '1', '-vf', `crop=2:2:${x}:${y},scale=1:1,format=rgb24`, '-f', 'rawvideo', '-'], { windowsHide: true });
+    if (result.status !== 0) throw new Error(result.stderr.toString());
+    return [...result.stdout];
+  }
+
+  it('preserves clip order and duration with mixed frame rates, VFR, rotation and silent sources', async () => {
+    expect(state.records.get(ids[3]!)!.analysis.video.variable_frame_rate).toBe(true);
+    expect(state.records.get(ids[2]!)!.analysis.video).toMatchObject({ width: 180, height: 320 });
+    const windowStub = { isDestroyed: () => false, webContents: {
+      send: (_channel: string, event: AppEvent) => { state.events.push(event); },
+    } } as unknown as BrowserWindow;
+    await startBatchExport(windowStub, { items: ids.map((analysis_id) => ({ analysis_id, selection })) });
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'batch-export-result' || event.type === 'error')).toBe(true), { timeout: 60_000 });
+    const terminal = state.events.find((event) => event.type === 'batch-export-result' || event.type === 'error')!;
+    if (terminal.type !== 'batch-export-result') throw new Error(JSON.stringify(terminal));
+    const metadata = await probeVideo(terminal.data.outputPath);
+    const durations = ids.map((id) => createCutGroups(state.records.get(id)!.analysis, selection)
+      .reduce((sum, group) => sum + group.end - group.start, 0));
+    expect(metadata).toMatchObject({ width: 320, height: 180, audio_codec: 'aac', audio_sample_rate: 48000, audio_channels: 2, video_codec: 'h264' });
+    expect(metadata.fps).toBeCloseTo(30000 / 1001, 2);
+    expect(Math.abs(metadata.duration_seconds - durations.reduce((sum, value) => sum + value, 0))).toBeLessThan(0.1);
+    expect(Math.abs(metadata.video_duration_seconds! - metadata.audio_duration_seconds!)).toBeLessThan(0.1);
+    const samples = [0, 1, 2, 3].map((index) => pixel(terminal.data.outputPath, durations.slice(0, index).reduce((sum, value) => sum + value, 0) + 1));
+    expect(samples[0]![0]).toBeGreaterThan(220);
+    expect(samples[0]![1]).toBeLessThan(30);
+    expect(samples[1]![1]).toBeGreaterThan(180);
+    expect(samples[1]![0]).toBeLessThan(40);
+    expect(samples[1]![2]).toBeLessThan(40);
+    expect(samples[2]![2]).toBeGreaterThan(220);
+    expect(samples[3]![0]).toBeGreaterThan(220);
+    expect(samples[3]![1]).toBeGreaterThan(220);
+    expect(pixel(terminal.data.outputPath, durations[0]! + 1, 2, 90).every((value) => value < 20)).toBe(true);
+    const silent = await runProcess(ffmpeg!, ['-hide_banner', '-ss', String(durations[0]! + 0.5), '-t', '1',
+      '-i', terminal.data.outputPath, '-vn', '-af', 'volumedetect', '-f', 'null', '-']);
+    const maximum = /max_volume: ([-\d.]+) dB/.exec(silent.stderr);
+    expect(Number(maximum?.[1])).toBeLessThan(-60);
+    expect((await readdir(root)).some((name) => name.startsWith('.ttcut-batch-'))).toBe(false);
+    if (process.env.TTCUT_BATCH_TEST_ROOT) await writeFile(path.join(root, 'validation.json'), JSON.stringify({ metadata, durations, samples, terminal }, null, 2));
+  }, 90_000);
+
+  it.each([
+    { sources: [1, 2], hasAudio: false, width: 180, height: 320, fps: 24 },
+    { sources: [1, 3], hasAudio: true, width: 180, height: 320, fps: 24 },
+    { sources: [3], hasAudio: true, width: 256, height: 144, fps: 30 },
+  ])('exports $sources with the first source profile and hasAudio=$hasAudio', async ({ sources, hasAudio, width, height, fps }) => {
+    const events: AppEvent[] = [];
+    const windowStub = { isDestroyed: () => false, webContents: {
+      send: (_channel: string, event: AppEvent) => { events.push(event); },
+    } } as unknown as BrowserWindow;
+    await startBatchExport(windowStub, { items: sources.map((index) => ({ analysis_id: ids[index], selection })) });
+    await vi.waitFor(() => expect(events.some((event) => event.type === 'batch-export-result' || event.type === 'error')).toBe(true), { timeout: 60_000 });
+    const terminal = events.find((event) => event.type === 'batch-export-result' || event.type === 'error')!;
+    if (terminal.type !== 'batch-export-result') throw new Error(JSON.stringify(terminal));
+    const metadata = await probeVideo(terminal.data.outputPath);
+    expect(metadata).toMatchObject({ width, height, audio_codec: hasAudio ? 'aac' : null });
+    expect(metadata.fps).toBeCloseTo(fps, 2);
+    expect(metadata.variable_frame_rate).toBe(false);
+  }, 90_000);
+});

--- a/tests/batch-export.test.ts
+++ b/tests/batch-export.test.ts
@@ -1,0 +1,156 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type { BrowserWindow } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppEvent } from '../src/shared/api';
+import { batchExportRequestSchema, type AnalysisResultV1, type HistoryRecordV1 } from '../src/shared/contracts';
+
+const state = vi.hoisted(() => ({
+  records: new Map<string, HistoryRecordV1>(),
+  events: [] as AppEvent[],
+  run: vi.fn(),
+  validate: vi.fn(),
+  open: vi.fn(),
+  markVisible: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('electron', () => ({ dialog: {} }));
+vi.mock('../src/main/logger', () => ({ logLine: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../src/main/history', () => ({ getHistoryStore: () => ({ open: state.open, markVisible: state.markVisible }) }));
+vi.mock('../src/main/media-protocol', () => ({ registerMediaPath: (value: string) => `media:${value}` }));
+vi.mock('../src/main/components', () => ({ resolveUsableMediaComponents: vi.fn().mockResolvedValue({
+  ffmpeg: 'ffmpeg', ffprobe: 'ffprobe', mediaEncoder: 'libx264',
+}) }));
+vi.mock('../src/main/export', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../src/main/export')>(),
+  assertExportPreconditions: vi.fn().mockResolvedValue(undefined),
+  runFfmpeg: state.run,
+  validateExportOutput: state.validate,
+}));
+
+import { startBatchExport } from '../src/main/batch-export';
+import { cancelAllTasksAndWait, cancelTask, hasActiveTasks } from '../src/main/processes';
+
+const ids = ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'];
+const selection = { mode: 'all', pre_roll_seconds: 1.5, post_roll_seconds: 0.5 } as const;
+const request = { items: ids.map((analysis_id) => ({ analysis_id, selection })) };
+const windowStub = { isDestroyed: () => false, webContents: { send: (_channel: string, event: AppEvent) => {
+  if (event.type === 'batch-export-result' || event.type === 'error') expect(hasActiveTasks()).toBe(false);
+  state.events.push(event);
+} } } as unknown as BrowserWindow;
+
+describe('batch export task', () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'ttcut-batch-test-'));
+    state.events.length = 0;
+    state.records.clear();
+    state.markVisible.mockClear();
+    state.open.mockReset().mockImplementation(async (id: string) => state.records.get(id));
+    state.run.mockReset().mockImplementation(async (_window, _id, _exe, args: string[]) => {
+      if (args.at(-1) !== '-') await writeFile(args.at(-1)!, 'validated-video');
+    });
+    state.validate.mockReset().mockImplementation(async (_file, _timing, profile) => ({ metadata: profile }));
+    for (const [index, id] of ids.entries()) {
+      const source = path.join(root, `video-${index}.mp4`);
+      const analysis: AnalysisResultV1 = {
+        schema_version: 1,
+        video: { path: source, duration_seconds: 8, width: 320, height: 180, fps: 30,
+          variable_frame_rate: false, video_codec: 'h264', audio_codec: null, container: 'mp4' },
+        rallies: [{ id: 'rally_001', index: 1, bounce_count: 5, start_time_seconds: 2, end_time_seconds: 3 }],
+      };
+      state.records.set(id, { id, analysis, source: { path: source, name: path.basename(source), size: 1, modified_time_ms: 1 } } as HistoryRecordV1);
+    }
+  });
+  afterEach(async () => {
+    await cancelAllTasksAndWait();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('rejects empty, duplicate, custom and path-bearing requests before reserving a task', async () => {
+    for (const value of [
+      { items: [] }, { items: [request.items[0], request.items[0]] },
+      { items: [{ analysis_id: ids[0], selection: { mode: 'custom', segments: [] } }] },
+      { ...request, outputPath: 'C:\\arbitrary.mp4' },
+    ]) {
+      expect(batchExportRequestSchema.safeParse(value).success).toBe(false);
+      await expect(startBatchExport(windowStub, value)).rejects.toThrow();
+      expect(hasActiveTasks()).toBe(false);
+    }
+  });
+
+  it('reserves the task before reading history and accepts cancellation during that read', async () => {
+    let release!: () => void;
+    const wait = new Promise<void>((resolve) => { release = resolve; });
+    state.open.mockImplementation(async (id: string) => { await wait; return state.records.get(id); });
+    const taskId = await startBatchExport(windowStub, request);
+    expect(hasActiveTasks()).toBe(true);
+    await expect(startBatchExport(windowStub, request)).rejects.toThrow('TASK_BUSY');
+    await cancelTask(taskId);
+    release();
+    await vi.waitFor(() => expect(state.events).toContainEqual(expect.objectContaining({ type: 'error', code: 'EXPORT_CANCELLED' })));
+    expect(state.run).not.toHaveBeenCalled();
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  it('skips empty sources while keeping the first participating source as output location', async () => {
+    state.records.get(ids[0]!)!.analysis.rallies = [];
+    await startBatchExport(windowStub, request);
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'batch-export-result')).toBe(true));
+    const result = state.events.find((event) => event.type === 'batch-export-result')!;
+    if (result.type !== 'batch-export-result') throw new Error('Missing result');
+    expect(result.data.outputPath).toBe(path.join(root, 'video-0_TTcut_合并集锦.mp4'));
+    expect(result.data.skippedAnalysisIds).toEqual([ids[0]]);
+    expect(await readdir(root)).toEqual(['video-0_TTcut_合并集锦.mp4']);
+    const segmentCalls = state.run.mock.calls.filter((call) => call[6]?.segmentIndex);
+    expect(segmentCalls).toHaveLength(1);
+    expect(segmentCalls[0]![3]).toContain(state.records.get(ids[1]!)!.analysis.video.path);
+  });
+
+  it('returns an empty-selection error without publishing a file', async () => {
+    state.records.forEach((record) => { record.analysis.rallies = []; });
+    await startBatchExport(windowStub, request);
+    await vi.waitFor(() => expect(state.events).toContainEqual(expect.objectContaining({ type: 'error', code: 'BATCH_EXPORT_EMPTY' })));
+    expect(state.run).not.toHaveBeenCalled();
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  it('retains a cached deferred analysis without assigning the merged output to its history', async () => {
+    state.records.get(ids[0]!)!.visible_in_history = false;
+    await startBatchExport(windowStub, request);
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'batch-export-result')).toBe(true));
+    expect(state.markVisible).toHaveBeenCalledExactlyOnceWith(ids[0], 'analysis');
+  });
+
+  it('skips an empty highlight selection but does not suppress an incompatible criterion', async () => {
+    const highlight = { mode: 'highlight', criterion: { kind: 'bounce_count', threshold: 7 }, pre_roll_seconds: 1.5, post_roll_seconds: 0.5 };
+    await startBatchExport(windowStub, { items: [{ analysis_id: ids[0], selection: highlight }, request.items[1]] });
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'batch-export-result')).toBe(true));
+    const result = state.events.find((event) => event.type === 'batch-export-result');
+    expect(result).toMatchObject({ data: { skippedAnalysisIds: [ids[0]] } });
+    state.events.length = 0;
+    await startBatchExport(windowStub, { items: [{ analysis_id: ids[0], selection: {
+      ...highlight, criterion: { kind: 'duration_tier', tier: 'rally' },
+    } }] });
+    await vi.waitFor(() => expect(state.events).toContainEqual(expect.objectContaining({ type: 'error', code: 'INVALID_HIGHLIGHT_CRITERION' })));
+  });
+
+  it('does not publish a partial batch after a segment fails', async () => {
+    state.run.mockImplementationOnce(async (_window, _id, _exe, args: string[]) => { await writeFile(args.at(-1)!, 'segment'); })
+      .mockRejectedValueOnce(new Error('segment failed'));
+    await startBatchExport(windowStub, request);
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'error')).toBe(true));
+    expect(state.events.some((event) => event.type === 'batch-export-result')).toBe(false);
+    expect(await readdir(root)).toEqual([]);
+  });
+
+  it('fully decodes before success and increments output collisions without replacing files', async () => {
+    const original = path.join(root, 'video-0_TTcut_合并集锦.mp4');
+    await writeFile(original, 'keep-me');
+    await startBatchExport(windowStub, request);
+    await vi.waitFor(() => expect(state.events.some((event) => event.type === 'batch-export-result')).toBe(true));
+    expect(state.run.mock.calls.at(-1)![3]).toEqual(expect.arrayContaining(['-xerror', '-f', 'null']));
+    expect(await readFile(original, 'utf8')).toBe('keep-me');
+    expect(await readdir(root)).toEqual(['video-0_TTcut_合并集锦.mp4', 'video-0_TTcut_合并集锦_2.mp4']);
+  });
+});

--- a/tests/batch-media-plan.test.ts
+++ b/tests/batch-media-plan.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { batchOutputProfile, batchSegmentDuration, buildBatchSegmentArgs } from '../src/main/batch-media-plan';
+import type { CutGroup, VideoMetadata } from '../src/shared/contracts';
+
+const video: VideoMetadata = {
+  path: 'C:\\match.mp4', duration_seconds: 10, width: 1920, height: 1080, fps: 29.8,
+  nominal_fps_ratio: '30000/1001', average_fps_ratio: '149/5', variable_frame_rate: true,
+  video_codec: 'h264', audio_codec: null, container: 'mp4',
+};
+const group: CutGroup = { start: 1.123, end: 4.567, rawStart: 2, rawEnd: 3, rallyIds: ['rally_001'] };
+
+describe('merged video encoding plan', () => {
+  it('uses the nominal rational frame rate, then the average, without mutating the input', () => {
+    const output = batchOutputProfile(video, true);
+    expect(output.fps).toBeCloseTo(30000 / 1001, 8);
+    expect(output).toMatchObject({ variable_frame_rate: false, audio_codec: 'aac', audio_channels: 2, audio_sample_rate: 48000 });
+    expect(video.variable_frame_rate).toBe(true);
+    expect(video.audio_codec).toBeNull();
+    expect(batchOutputProfile({ ...video, nominal_fps_ratio: '0/0' }, false).fps).toBeCloseTo(29.8, 8);
+    expect(batchOutputProfile({ ...video, nominal_fps_ratio: null, average_fps_ratio: null }, false).fps).toBeCloseTo(29.8, 8);
+  });
+
+  it('quantizes each clip to whole output frames and uses an exactly divisible track timescale', () => {
+    const profile = batchOutputProfile(video, false);
+    const duration = batchSegmentDuration(group, profile);
+    expect(Math.abs(duration - (group.end - group.start))).toBeLessThanOrEqual(0.5 / profile.fps);
+    const args = buildBatchSegmentArgs(video, profile, group, 'out.mp4', 'libx264');
+    expect(args[args.indexOf('-video_track_timescale') + 1]).toBe('30000');
+    expect(args[args.indexOf('-r') + 1]).toBe('30000/1001');
+    expect(args).toContain('-bf');
+    expect(args).not.toContain('[aout]');
+  });
+
+  it('pads rather than stretches portrait media and supplies silent audio only when required', () => {
+    const profile = batchOutputProfile(video, true);
+    const args = buildBatchSegmentArgs({ ...video, width: 1080, height: 1920, rotation: 90 }, profile, group, 'out.mp4', 'libopenh264');
+    expect(args).toContain('-autorotate');
+    expect(args).toContain('anullsrc=r=48000:cl=stereo');
+    expect(args[args.indexOf('-filter_complex') + 1]).toContain('force_original_aspect_ratio=decrease');
+    expect(args[args.indexOf('-filter_complex') + 1]).toContain('pad=1920:1080:');
+    expect(args).not.toContain('-bf');
+  });
+});

--- a/tests/multi-task-page.test.tsx
+++ b/tests/multi-task-page.test.tsx
@@ -62,6 +62,7 @@ describe('multi-task clipping', () => {
       startAutoCalibration,
       startAnalysis,
       startExport,
+      startBatchExport: vi.fn().mockResolvedValue('batch-export-1'),
       onTaskEvent: vi.fn((next: (event: AppEvent) => void) => {
         listener = next;
         return () => { listener = null; };
@@ -91,6 +92,178 @@ describe('multi-task clipping', () => {
       tableAnalysis,
     }));
   }
+
+  async function prepareMergedBatch(onFinished = vi.fn(), initialVideos = videos) {
+    render(<MultiTaskPage initialVideos={initialVideos} preRoll={2.5} postRoll={1}
+      onOpenAnalysis={vi.fn()} onCompletableTasksFinished={onFinished} />);
+    for (let index = 0; index < initialVideos.length; index += 1) {
+      await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(index + 1));
+      await finishCalibration(`calibration-task-${index + 1}`);
+    }
+    fireEvent.click(screen.getByRole('checkbox', { name: '合并为一个视频' }));
+    return onFinished;
+  }
+
+  async function finishAnalysis(index: number, path = videos[index - 1]!.path) {
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(index));
+    act(() => listener?.({ type: 'analysis-result', taskId: `analysis-task-${index}`,
+      analysisId: `${index}${'1'.repeat(7)}-1111-4111-8111-111111111111`, calibration, data: analysis(path) }));
+  }
+
+  it('merges in addition order and shuts down only after the merged result arrives', async () => {
+    const finished = await prepareMergedBatch();
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    expect(screen.getByRole('checkbox', { name: '合并为一个视频' })).toBeDisabled();
+    await finishAnalysis(1);
+    await finishAnalysis(2);
+    expect(startAnalysis.mock.calls.every((call) => call[0].historyVisibility === 'visible')).toBe(true);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    expect(startExport).not.toHaveBeenCalled();
+    expect(window.ttcut.startBatchExport).toHaveBeenCalledWith({ items: [
+      { analysis_id: '11111111-1111-4111-8111-111111111111', selection: { mode: 'all', pre_roll_seconds: 2.5, post_roll_seconds: 1 } },
+      { analysis_id: '21111111-1111-4111-8111-111111111111', selection: { mode: 'all', pre_roll_seconds: 2.5, post_roll_seconds: 1 } },
+    ] });
+    expect(finished).not.toHaveBeenCalled();
+    expect(window.ttcut.shutdownSystem).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: '＋ 添加视频' })).toBeDisabled();
+    for (const group of screen.getAllByRole('group')) {
+      expect(within(group).getByRole('button', { name: '所有回合' })).toBeDisabled();
+    }
+    expect(screen.getByRole('checkbox', { name: '完成本任务后关机' })).not.toBeDisabled();
+    act(() => listener?.({ type: 'progress', data: { taskId: 'batch-export-1', kind: 'export', stage: 'concatenating', percent: 90 } }));
+    expect(screen.getByRole('progressbar')).toHaveAttribute('value', '90');
+    act(() => listener?.({ type: 'batch-export-result', taskId: 'batch-export-1', data: {
+      outputPath: 'C:\\video\\first_TTcut_合并集锦.mp4', mediaUrl: 'ttcut-media://merged',
+      width: 1280, height: 720, skippedAnalysisIds: [],
+    } }));
+    await waitFor(() => expect(window.ttcut.shutdownSystem).toHaveBeenCalledTimes(1));
+    expect(finished).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('合并视频已完成')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: '预览输出' }));
+    expect(document.querySelector('.batch-preview video')).toHaveAttribute('src', 'ttcut-media://merged');
+  });
+
+  it('disables and unchecks merging when every video is analysis only, including an empty list', async () => {
+    await prepareMergedBatch();
+    for (const group of screen.getAllByRole('group')) {
+      fireEvent.click(within(group).getByRole('button', { name: '只分析' }));
+    }
+    const merge = screen.getByRole('checkbox', { name: '合并为一个视频' });
+    expect(merge).toBeDisabled();
+    expect(merge).not.toBeChecked();
+    expect(merge.closest('label')).toHaveAttribute('title', '至少一个视频选择“所有回合”或“精彩回合”后可用。');
+    for (const video of videos) fireEvent.click(screen.getByRole('button', { name: `删除 ${video.name}` }));
+    expect(merge).toBeDisabled();
+    expect(merge).not.toBeChecked();
+  });
+
+  it('allows one participating video and excludes analysis-only videos', async () => {
+    await prepareMergedBatch();
+    fireEvent.click(within(screen.getByRole('group', { name: 'second.mp4 的剪辑模式' })).getByRole('button', { name: '只分析' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await finishAnalysis(1);
+    await finishAnalysis(2);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(window.ttcut.startBatchExport).mock.calls[0]![0].items).toHaveLength(1);
+    expect(startExport).not.toHaveBeenCalled();
+  });
+
+  it('uses edits to an already analyzed item and includes videos added during analysis', async () => {
+    await prepareMergedBatch();
+    vi.mocked(window.ttcut.selectVideos).mockResolvedValue([thirdVideo]);
+    startAnalysis.mockResolvedValueOnce('analysis-task-3');
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await finishAnalysis(1);
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(2));
+    fireEvent.click(within(screen.getByRole('group', { name: 'first.mp4 的剪辑模式' })).getByRole('button', { name: '精彩回合' }));
+    fireEvent.click(screen.getByRole('radio', { name: '长相持' }));
+    fireEvent.click(screen.getByRole('button', { name: '＋ 添加视频' }));
+    await screen.findByText('third.mp4');
+    await finishAnalysis(2);
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(3));
+    await finishCalibration('calibration-task-3');
+    await finishAnalysis(3, thirdVideo.path);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    const request = vi.mocked(window.ttcut.startBatchExport).mock.calls[0]![0];
+    expect(request.items.map((item) => item.analysis_id[0])).toEqual(['1', '2', '3']);
+    expect(request.items[0]!.selection).toMatchObject({ mode: 'highlight', criterion: { kind: 'duration_tier', tier: 'long_rally' } });
+    expect(startAnalysis).toHaveBeenCalledTimes(3);
+  });
+
+  it('blocks merging after a cancelled item and reuses completed analysis on retry', async () => {
+    const finished = await prepareMergedBatch();
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: '取消 first.mp4' }));
+    act(() => listener?.({ type: 'error', taskId: 'analysis-task-1', code: 'ANALYSIS_CANCELLED', message: 'cancelled' }));
+    await finishAnalysis(2);
+    await screen.findByText('请完成标定、重试或移除未完成的视频后再合并。');
+    expect(window.ttcut.startBatchExport).not.toHaveBeenCalled();
+    expect(finished).not.toHaveBeenCalled();
+    expect(window.ttcut.shutdownSystem).not.toHaveBeenCalled();
+    startAnalysis.mockResolvedValueOnce('analysis-task-3');
+    fireEvent.click(screen.getByRole('button', { name: '重试合并' }));
+    await finishAnalysis(3, videos[0]!.path);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(window.ttcut.startBatchExport).mock.calls[0]![0].items.map((item) => item.analysis_id[0])).toEqual(['3', '2']);
+    expect(startAnalysis).toHaveBeenCalledTimes(3);
+  });
+
+  it('waits for an open add-video dialog before taking the final merge snapshot', async () => {
+    await prepareMergedBatch(vi.fn(), videos.slice(0, 1));
+    let resolveSelection!: (videos: SelectedVideo[]) => void;
+    vi.mocked(window.ttcut.selectVideos).mockImplementation(() => new Promise((resolve) => { resolveSelection = resolve; }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole('button', { name: '＋ 添加视频' }));
+    await finishAnalysis(1);
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+    expect(window.ttcut.startBatchExport).not.toHaveBeenCalled();
+    await act(async () => { resolveSelection([videos[1]!]); });
+    await waitFor(() => expect(startAutoCalibration).toHaveBeenCalledTimes(2));
+    await finishCalibration('calibration-task-2');
+    await finishAnalysis(2);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(window.ttcut.startBatchExport).mock.calls[0]![0].items).toHaveLength(2);
+  });
+
+  it('does not request shutdown when a merged batch contains an analysis warning', async () => {
+    await prepareMergedBatch(vi.fn(), videos.slice(0, 1));
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await waitFor(() => expect(startAnalysis).toHaveBeenCalledTimes(1));
+    act(() => listener?.({ type: 'analysis-result', taskId: 'analysis-task-1',
+      analysisId: '11111111-1111-4111-8111-111111111111', calibration,
+      data: { ...analysis(videos[0]!.path), processing: {
+        mode: 'vfr_fallback', warning_code: 'CFR_FALLBACK',
+      } } as AnalysisResultV1,
+    }));
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    act(() => listener?.({ type: 'batch-export-result', taskId: 'batch-export-1', data: {
+      outputPath: 'C:\\merged.mp4', mediaUrl: 'ttcut-media://merged', width: 1920, height: 1080, skippedAnalysisIds: [],
+    } }));
+    expect(window.ttcut.shutdownSystem).not.toHaveBeenCalled();
+  });
+
+  it.each(['EXPORT_FAILED', 'EXPORT_CANCELLED', 'BATCH_EXPORT_EMPTY'])('does not shut down for %s and retries export without analysis', async (code) => {
+    const finished = await prepareMergedBatch(vi.fn(), videos.slice(0, 1));
+    fireEvent.click(screen.getByRole('checkbox', { name: '完成本任务后关机' }));
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await finishAnalysis(1);
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(1));
+    if (code === 'EXPORT_CANCELLED') {
+      fireEvent.click(screen.getByRole('button', { name: '取消' }));
+      expect(window.ttcut.cancelTask).toHaveBeenCalledWith('batch-export-1');
+    }
+    act(() => listener?.({ type: 'error', taskId: 'batch-export-1', code, message: code }));
+    expect(finished).not.toHaveBeenCalled();
+    expect(window.ttcut.shutdownSystem).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: '重试合并' }));
+    await waitFor(() => expect(window.ttcut.startBatchExport).toHaveBeenCalledTimes(2));
+    expect(startAnalysis).toHaveBeenCalledTimes(1);
+  });
 
   it('auto-calibrates sequentially before allowing mode selection', async () => {
     render(<MultiTaskPage initialVideos={videos} preRoll={2.5} postRoll={1} onOpenAnalysis={vi.fn()} />);


### PR DESCRIPTION
多任务页面的关机选项因共用悬停样式改为依赖 `is-open` 而不可见。本次恢复入口，并将“完成本任务后关机”和新增“合并为一个视频”放在同一面板，复用自定义页面的面板与复选框样式。

勾选合并后，按视频添加顺序将各项“所有回合”或“精彩回合”选出的片段导出为一个 MP4；“只分析”不参与，全部只分析时禁用合并。未勾选时保留逐视频导出。成片保存到首个参与视频旁，文件重名自动编号。

合并使用独立 IPC 和任务生命周期，支持分析期间添加视频、调整条件，以及取消和重试。空片段跳过，失败项阻止生成缺项成片。统一画面及音轨规格，校验时长、音画同步与完整解码后才报告成功；完成后关机等待最终合并成功。各源视频仍保留独立分析历史。

验证：

- 类型检查通过；完整测试 297 项通过、21 项按运行条件跳过。
- 最后一次样式调整后，多任务及自定义页面相关测试 30/30 通过。
- 显式启用真实媒体测试，OpenH264 和 x264 各 4/4 通过，覆盖混合尺寸、横竖屏、旋转、分数帧率、VFR、有无音轨及单参与视频。
- 本地打包通过；真实 Electron 验证统一悬停面板、禁用状态、合并导出、预览及文件夹入口，无页面运行错误；包内 5 个生产 JS/CSS/HTML 文件与验证资源一致。
- Electron 验证使用预置分析结果，并拦截操作系统关机；未重新验证球检测模型效果。

不包含版本升级、签名或发布。
