### PR TITLE
Fix normalized media paths and multi-task completion layout

### DIFF
--- a/src/main/processing-media.ts
+++ b/src/main/processing-media.ts
@@ -448,7 +448,7 @@ export async function prepareProcessingMedia(
       existingDirectoryMoved = false;
     }
     return {
-      metadata,
+      metadata: { ...metadata, path: mediaPath },
       mode: 'normalized_cfr',
       targetFpsRatio,
       encoder,

--- a/src/renderer/MultiTaskPage.tsx
+++ b/src/renderer/MultiTaskPage.tsx
@@ -191,7 +191,6 @@ export function MultiTaskPage({
     mergeCancelled: isEnglish ? 'Merged export cancelled. Analysis results are retained.' : '已取消合并导出，分析结果已保留。',
     mergeSkipped: isEnglish ? 'No matching clips; skipped:' : '没有符合条件的片段，已跳过：',
     retry: isEnglish ? 'Retry merge' : '重试合并',
-    viewAnalysis: isEnglish ? 'View analysis' : '查看分析',
     previewOutput: isEnglish ? 'Preview output' : '预览输出',
     openFolder: isEnglish ? 'Open folder' : '打开文件夹',
     calibrationTitle: isEnglish ? 'Calibrate the table' : '标定球桌',
@@ -786,7 +785,7 @@ export function MultiTaskPage({
           const rowStatus = done ? 'done' : active ? 'processing' : manualRequired ? 'manual-required' : item.calibrationStatus === 'error' ? 'failed' : item.processingStatus;
           return (
             <article
-              className={`batch-row card ${rowStatus}`}
+              className={`batch-row card ${rowStatus}${mergeWorkflow ? ' merge-workflow' : ''}`}
               key={item.id}
               ref={(element) => { if (element) rowRefs.current.set(item.id, element); else rowRefs.current.delete(item.id); }}
             >
@@ -823,10 +822,6 @@ export function MultiTaskPage({
                 <strong title={item.video.name}>{item.video.name}</strong>
                 <span>{formatTimestamp(item.metadata.duration_seconds)} · {item.metadata.width} × {item.metadata.height} · {item.metadata.fps.toFixed(3)} fps</span>
                 {mergeWorkflow && done && item.mode !== 'analyze-only' && batchExport.status !== 'done' && <span>{text.mergeWaiting}</span>}
-                {mergeWorkflow && item.analysisId && (
-                  <button className="text-button" type="button" disabled={batchTaskActive}
-                    onClick={() => onOpenAnalysis(item.analysisId!)}>{text.viewAnalysis}</button>
-                )}
                 {item.error && !manualRequired && <small>{item.error}</small>}
                 {item.exportWarning && (
                   <div className="batch-export-warning" role="alert">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -495,7 +495,8 @@ td input { accent-color: var(--blue); }
 .multi-header h1 { margin: 0 auto 0 0; font-size: var(--page-title-size); }
 .batch-list { display: grid; gap: 12px; }
 .batch-row { min-height: 138px; padding: 12px; display: grid; grid-template-columns: 200px minmax(180px, 1fr) minmax(180px, 260px) 36px; align-items: center; gap: 16px; overflow: hidden; }
-.batch-row.done { order: -1; grid-template-columns: 200px minmax(180px, 1fr) auto; }
+.batch-row.done { order: -1; }
+.batch-row.done:not(.merge-workflow) { grid-template-columns: 200px minmax(180px, 1fr) auto; }
 .batch-cover { position: relative; width: 200px; aspect-ratio: 16 / 9; padding: 0; overflow: hidden; border: 0; border-radius: 10px; background: #161616; cursor: pointer; }
 .batch-cover video { width: 100%; height: 100%; object-fit: cover; }
 .batch-cover.processing video { filter: blur(8px); transform: scale(1.08); opacity: .66; }
@@ -660,7 +661,7 @@ td input { accent-color: var(--blue); }
   .mode-grid { grid-template-columns: 1fr; }
   .mode-card { min-height: 78px; }
   .batch-row, .batch-row.done { grid-template-columns: 160px minmax(150px, 1fr) minmax(150px, 210px) 32px; }
-  .batch-row.done { grid-template-columns: 160px minmax(150px, 1fr) auto; }
+  .batch-row.done:not(.merge-workflow) { grid-template-columns: 160px minmax(150px, 1fr) auto; }
   .batch-cover { width: 160px; }
   .toast { left: calc(50% + 92px); }
 }

--- a/tests/multi-task-page.test.tsx
+++ b/tests/multi-task-page.test.tsx
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MultiTaskPage } from '../src/renderer/MultiTaskPage';
@@ -147,6 +148,37 @@ describe('multi-task clipping', () => {
     expect(screen.getByText('合并视频已完成')).toBeVisible();
     fireEvent.click(screen.getByRole('button', { name: '预览输出' }));
     expect(document.querySelector('.batch-preview video')).toHaveAttribute('src', 'ttcut-media://merged');
+  });
+
+  it('keeps merge controls in the same grid columns after analysis completes', async () => {
+    await prepareMergedBatch();
+    const rowBefore = screen.getByText('first.mp4').closest('.batch-row');
+    expect(rowBefore).not.toBeNull();
+    expect(rowBefore).toHaveClass('merge-workflow');
+    const expectStableSlots = (row: Element) => {
+      const children = Array.from(row.children);
+      expect(children).toHaveLength(4);
+      expect(children[0]).toHaveClass('batch-cover');
+      expect(children[1]).toHaveClass('batch-info');
+      expect(children[2]).toHaveClass('batch-mode');
+      expect(children[3]).toHaveClass('batch-remove');
+    };
+    expectStableSlots(rowBefore!);
+    const styles = readFileSync('src/renderer/styles.css', 'utf8');
+    const baseRule = styles.match(/\.batch-row\s*\{([^}]*)\}/)?.[1] ?? '';
+    const doneRules = [...styles.matchAll(/(?:^|\n)\.batch-row\.done\s*\{([^}]*)\}/g)]
+      .map((match) => match[1] ?? '');
+    expect(baseRule).toContain('grid-template-columns: 200px minmax(180px, 1fr) minmax(180px, 260px) 36px;');
+    expect(doneRules).not.toHaveLength(0);
+    expect(doneRules.every((rule) => !rule.includes('grid-template-columns'))).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: '开始分析剪辑' }));
+    await finishAnalysis(1);
+
+    const rowAfter = screen.getByText('first.mp4').closest('.batch-row');
+    expect(rowAfter).toHaveClass('done', 'merge-workflow');
+    expectStableSlots(rowAfter!);
+    expect(screen.queryByRole('button', { name: '查看分析' })).toBeNull();
   });
 
   it('disables and unchecks merging when every video is analysis only, including an empty list', async () => {

--- a/tests/processing-media-publish.test.ts
+++ b/tests/processing-media-publish.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { VideoMetadata } from '../src/shared/contracts';
+
+const mocks = vi.hoisted(() => ({
+  componentsRoot: '',
+  probe: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('../src/main/components', () => ({
+  managedComponentsRoot: () => mocks.componentsRoot,
+}));
+vi.mock('../src/main/probe', () => ({ probeVideo: mocks.probe }));
+vi.mock('../src/main/processes', () => ({
+  getTaskController: () => undefined,
+  spawnTracked: mocks.spawn,
+}));
+
+let directory: string;
+let sourcePath: string;
+let service: typeof import('../src/main/processing-media');
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  directory = await mkdtemp(path.join(os.tmpdir(), 'ttcut-processing-media-test-'));
+  mocks.componentsRoot = path.join(directory, 'components');
+  sourcePath = path.join(directory, 'source.mp4');
+  await writeFile(sourcePath, 'source video');
+
+  mocks.probe.mockImplementation(async (file: string): Promise<VideoMetadata> => ({
+    path: file,
+    duration_seconds: 10,
+    width: 1920,
+    height: 1080,
+    fps: 30,
+    frame_count: 300,
+    variable_frame_rate: false,
+    nominal_fps: 30,
+    nominal_fps_ratio: '30/1',
+    average_fps_ratio: '30/1',
+    video_codec: 'h264',
+    audio_codec: 'aac',
+    container: 'mp4',
+  }));
+  mocks.spawn.mockImplementation((_taskId: string, _executable: string, args: string[]) => {
+    const child = new EventEmitter() as EventEmitter & {
+      killed: boolean;
+      kill: ReturnType<typeof vi.fn>;
+      stdin: { end: () => void };
+      stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+      stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+    };
+    child.killed = false;
+    child.kill = vi.fn();
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.stdin = {
+      end: () => {
+        void writeFile(args.at(-1)!, Buffer.alloc(2048)).then(() => child.emit('close', 0, null));
+      },
+    };
+    return child;
+  });
+  service = await import('../src/main/processing-media');
+});
+
+afterEach(async () => {
+  await rm(directory, { recursive: true, force: true });
+});
+
+describe('processing media publication', () => {
+  it('returns the published cache path after creating normalized media', async () => {
+    const source: VideoMetadata = {
+      path: sourcePath,
+      duration_seconds: 10,
+      width: 1920,
+      height: 1080,
+      fps: 30,
+      frame_count: 300,
+      variable_frame_rate: true,
+      nominal_fps: 30,
+      nominal_fps_ratio: '30/1',
+      average_fps_ratio: '30/1',
+      video_codec: 'h264',
+      audio_codec: 'aac',
+      container: 'mp4',
+    };
+
+    const result = await service.prepareProcessingMedia(
+      'task-1',
+      source,
+      'libx264',
+      'ffmpeg',
+      new AbortController().signal,
+      vi.fn(),
+    );
+
+    expect(result.metadata.path).toBe(result.cachePath);
+    expect(result.metadata.path).not.toContain('.partial');
+    await expect(stat(result.metadata.path)).resolves.toMatchObject({ size: 2048 });
+
+    const cached = await service.prepareProcessingMedia(
+      'task-2',
+      source,
+      'libx264',
+      'ffmpeg',
+      new AbortController().signal,
+      vi.fn(),
+    );
+    expect(cached.metadata.path).toBe(result.metadata.path);
+    expect(cached.cacheCreated).toBe(false);
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- preserve the canonical normalized-media cache path after staging is published, preventing VIDEO_UNREADABLE
- remove the merge-workflow View analysis link
- keep mode and delete controls in stable grid columns after analysis

## Testing

- npm.cmd test -- tests/processing-media-publish.test.ts tests/processing-media.test.ts tests/calibration.test.ts tests/multi-task-page.test.tsx
- npm.cmd run typecheck
- git diff --check origin/develop...HEAD

## Not run

- the unavailable reported source video
- a real Electron pixel-level visual regression